### PR TITLE
Export the function that gets an address from a symbol name

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"C"
 	"bufio"
 	"bytes"
 	"encoding/json"
@@ -393,4 +394,42 @@ func main() {
 			fmt.Println(DataToJson((metadata)))
 		}
 	}
+}
+
+//export SymbolToAddress
+func SymbolToAddress(fileName, symbol string) (addr uintptr, size int) {
+	metadata, err := main_impl(fileName, true, false, true, 0, "")
+	if err != nil {
+		return 0, 0
+	}
+
+	for _, f := range metadata.StdFunctions {
+		if f.FullName != symbol {
+			continue
+		}
+		return uintptr(f.Start), int(f.End) - int(f.Start)
+	}
+
+	for _, f := range metadata.UserFunctions {
+		if f.FullName != symbol {
+			continue
+		}
+		return uintptr(f.Start), int(f.End) - int(f.Start)
+	}
+
+	for _, t := range metadata.Types {
+		if t.Str != symbol {
+			continue
+		}
+		return uintptr(t.VA), 0
+	}
+
+	for _, t := range metadata.Interfaces {
+		if t.Str != symbol {
+			continue
+		}
+		return uintptr(t.VA), 0
+	}
+
+	return 0, 0
 }

--- a/objfile/objfile.go
+++ b/objfile/objfile.go
@@ -1528,7 +1528,7 @@ func (e *Entry) ParseITabLinks(runtimeVersion string, moduleData *ModuleData, is
 		if err == nil && err2 == nil && len(parsed) > 0 && len(parsed2) > 0 {
 			interfaceName := parsed[0].Str
 			implementerName := parsed2[0].Str
-			types = append(types, Type{VA: itabAddr, Str: fmt.Sprintf("interface_%s_impl_%s", interfaceName, implementerName), Kind: Interface.String()})
+			types = append(types, Type{VA: itabAddr, Str: fmt.Sprintf("go.itab.%s,%s", implementerName, interfaceName), Kind: Interface.String()})
 		}
 	}
 	return types, nil


### PR DESCRIPTION
Export functions to make it easier for other languages ​​to load as libraries.

```bash
go build -buildmode=c-shared -o libGoReSym.so
```

then, use it in c 

```c
#include <stdio.h>
#include <dlfcn.h>
#include <assert.h>
#include <stddef.h>

typedef signed char GoInt8;
typedef unsigned char GoUint8;
typedef short GoInt16;
typedef unsigned short GoUint16;
typedef int GoInt32;
typedef unsigned int GoUint32;
typedef long long GoInt64;
typedef unsigned long long GoUint64;
typedef GoInt64 GoInt;
typedef GoUint64 GoUint;
typedef size_t GoUintptr;
typedef float GoFloat32;
typedef double GoFloat64;
typedef struct { const char *p; ptrdiff_t n; } GoString;
typedef void *GoMap;
typedef void *GoChan;
typedef struct { void *t; void *v; } GoInterface;
typedef struct { void *data; GoInt len; GoInt cap; } GoSlice;

struct Func
{
        GoUintptr addr;
        GoInt size;
};

int main()
{
        void *dlfile = dlopen("./libGoReSym.so", RTLD_LAZY);
        assert(dlfile);

        struct Func (*GetFuncBySym)(GoString, GoString) = dlsym(dlfile, "GetFuncBySym");
        assert(GetFuncBySym);

        GoString filename;
        GoString symname;

        filename.p = "GoReSym";
        filename.n = sizeof("GoReSym") - 1;

        symname.p = "runtime.casgstatus";
        symname.n = sizeof("runtime.casgstatus") - 1;

        struct Func func = GetFuncBySym(filename, symname);
        printf("addr=[%p]\n", func.addr);
        printf("size=[%d]\n", func.size);

        dlclose(dlfile);
        return 0;
}
```

output

```txt
addr=[0x43ae00]
size=[384]
```
