### PR TITLE
Adding a 'best guess' scenario for the scanner to attempt to find and repair a pclntab with bad magic

### DIFF
--- a/objfile/elf.go
+++ b/objfile/elf.go
@@ -125,6 +125,29 @@ ExitScan:
 					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
+            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+            //      for analysis purposes
+            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+            matches = findAllOccurrences(data, internal_sig)
+            for _, internal_idx := range matches {
+                if internal_idx != -1 {
+                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+                    for _, sig := range pclntab_sigs {
+                        pclntab = append(sig, data[pclntab_idx+6:]...)
+                    
+					    var candidate PclntabCandidate
+					    candidate.Pclntab = pclntab
+
+					    candidate.SecStart = uint64(sec.Addr)
+					    candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+					    candidates = append(candidates, candidate)
+                    }
+                }
+            }
 		} else {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -143,6 +143,29 @@ ExitScan:
 					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
+            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+            //      for analysis purposes
+            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+            matches = findAllOccurrences(data, internal_sig)
+            for _, internal_idx := range matches {
+                if internal_idx != -1 {
+                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+                    for _, sig := range pclntab_sigs {
+                        pclntab = append(sig, data[pclntab_idx+6:]...)
+                    
+					    var candidate PclntabCandidate
+					    candidate.Pclntab = pclntab
+
+					    candidate.SecStart = uint64(sec.Addr)
+					    candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+					    candidates = append(candidates, candidate)
+                    }
+                }
+            }
 		} else {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)


### PR DESCRIPTION
Hello!

I recently ran across some packed/obfuscated Go samples that modify the pclntab magic bytes. This causes GoReSym to have issues parsing the table, particularly it seems when you try to load the table with what I assume is the runtime code.

This patch is something that I scripted in python for myself, but I still use GoReSym to repair the symbols after fixing the pclntab magic bytes, so I figured we may consolidate here and offer the patch as well in this PR.

I'm not too familiar with the runtime, nor the GoReSym codebase, so it might be possible to optimize the repair by adding it to another portion of code, although here is how it currently works:

- Find the first package/function in the pclntab (almost always internal/cpu.Initialize)
- go to the top of the struct (96 bytes before this entry)
- add pclntab candidates for the struct, but replace the first 6 bytes with the list of sigs specified in the scanner function
  - This adds one candidate for each signature in the signature list 

At this point, they are added to the list of candidates and can be used when attempting to find suitable candidates by loading the symbol table using the runtime code.

Again, not super familiarized with GoReSym project, but this has been an ongoing hangup for obfuscated/packed Go samples and here is a somewhat reasonable solution.

If you have any questions, comments, or concerns, let me know.
Thanks!