### PR TITLE
Adding a 'best guess' scenario for the scanner to attempt to find and repair a pclntab with bad magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Ignoring some trivial changes, most new logic exists in `/objfile`. For example,
 * `buildID` Legacy bug: [golang/go#50809](https://github.com/golang/go/issues/50809)
 
 # Changes
+*   GoReSym will now also attempt to find the pclntab based on a signature of the `runtime_modulesinit` initialization method and attempt to repair the pclntab magic (in cases where the pclntab magic has been modified).
 *   Extended `pcln()` functions in `objfile/<fileformat>` to support byte scanning the `pclntab` magic
 *   Added routines such as `DataAfterSection` to support signature scan in file format parsers in `/debug/<fileformat>`
 *  Added check to `debug/gosym/symtab.go`'s `walksymtab` to bail early when the optional `symtab` section is empty

--- a/debug/gosym/pclntab.go
+++ b/debug/gosym/pclntab.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -350,7 +351,12 @@ func (t *LineTable) go12Funcs() []Func {
 		}()
 	}
 
+	// avoid OOM error on corrupt binaries
 	ft := t.funcTab()
+	if ft.Count() >= math.MaxUint16 {
+		return make([]Func, 1)
+	}
+
 	funcs := make([]Func, ft.Count())
 	syms := make([]Sym, len(funcs))
 	for i := range funcs {

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	google.golang.org/protobuf v1.28.1
 )
 
-require github.com/elliotchance/orderedmap v1.4.0
+require (
+	github.com/elliotchance/orderedmap v1.4.0
+	github.com/hillu/go-yara/v4 v4.3.2
+)

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/elliotchance/orderedmap v1.4.0/go.mod h1:wsDwEaX5jEoyhbs7x93zk2H/qv0z
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hillu/go-yara/v4 v4.3.2 h1:HGqUN3ORUduWZbb95RQjut4UzavGDbtt/C6SnGB3Amk=
+github.com/hillu/go-yara/v4 v4.3.2/go.mod h1:AHEs/FXVMQKVVlT6iG9d+q1BRr0gq0WoAWZQaZ0gS7s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -218,7 +218,13 @@ restartParseWithRealTextBase:
 		// The resolved offsets within the pclntab might have used the wrong base though! We'll fix that later.
 		_, tmpModData, err := file.ModuleDataTable(tab.PclntabVA, extractMetadata.Version, extractMetadata.TabMeta.Version, extractMetadata.TabMeta.PointerSize == 8, extractMetadata.TabMeta.Endianess == "LittleEndian")
 		if err == nil && tmpModData != nil {
-			if knownGoTextBase == 0 {
+			// if the search candidate relied on a moduledata va, make sure it lines up with ours now
+			stomppedMagicMetaConstraintsValid := true
+			if tab.StompMagicCandidateMeta != nil {
+				stomppedMagicMetaConstraintsValid = tab.StompMagicCandidateMeta.SuspectedModuleDataVa == tmpModData.VA
+			}
+
+			if knownGoTextBase == 0 && stomppedMagicMetaConstraintsValid {
 				// assign real base and restart pclntab parsing with correct VAs!
 				// TODO: optimize, we should only restart pclntab parsing of the candidates we know find a moduledata
 				knownGoTextBase = tmpModData.TextVA

--- a/objfile/elf.go
+++ b/objfile/elf.go
@@ -89,29 +89,32 @@ func (f *elfFile) symbols() ([]Sym, error) {
 func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
-	symbol_method := false
 	var pclntab []byte
-	var pclntab_sym []byte
 	if sect := f.elf.Section(".gopclntab"); sect != nil {
-		if pclntab_sym, err = sect.Data(); err == nil {
+		if pclntab, err = sect.Data(); err == nil {
 			foundpcln = true
 		}
 	}
 
-	// 2) if not found, byte scan for it
-
-	var virtualOffset uint64 = 0
-	var pclntabPtr uint32 = 0
-	pclntab_sigs := [][]byte{
-		[]byte("\xF1\xFF\xFF\xFF\x00\x00"),
+	pclntab_sigs_le := [][]byte{
+		[]byte("\xF1\xFF\xFF\xFF\x00\x00"), // little endian
 		[]byte("\xF0\xFF\xFF\xFF\x00\x00"),
 		[]byte("\xFA\xFF\xFF\xFF\x00\x00"),
-		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),   
-		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), 
-		[]byte("\xFF\xFF\xFF\xFA\x00\x00"), 
-		[]byte("\xFF\xFF\xFF\xF0\x00\x00"), 
+		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),
+	}
+
+	pclntab_sigs_be := [][]byte{
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), // big endian
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xF0\x00\x00"),
 		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
 	}
+
+	// 2) if not found, byte scan for it
+	pclntab_sigs := append(pclntab_sigs_le, pclntab_sigs_be...)
+
+	// candidate array for method 4 of scanning
+	var stompedmagic_candidates []StompMagicCandidate = make([]StompMagicCandidate, 0)
 	for _, sec := range f.elf.Sections {
 		// first section is all zeros, skip
 		if sec.Type == elf.SHT_NULL {
@@ -119,80 +122,126 @@ func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 		}
 
 		data := f.elf.DataAfterSection(sec)
-		sectionData, _ := sec.Data()
-		if uint64(len(data)) < sec.Size {
-			continue
-		}
+		if !foundpcln {
+			// malware can split the pclntab across multiple sections, re-merge
+			// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
+			matches := findAllOccurrences(data, pclntab_sigs)
+			for _, pclntab_idx := range matches {
+				if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
+					pclntab = data[pclntab_idx:]
 
-		// malware can split the pclntab across multiple sections, re-merge
-		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-		matches := findAllOccurrences(data, pclntab_sigs)
-		for _, pclntab_idx := range matches {
-			if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
-				pclntab = data[pclntab_idx:]
-
-				var candidate PclntabCandidate
-				candidate.Pclntab = pclntab
-
-				candidate.SecStart = uint64(sec.Addr)
-				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-				candidates = append(candidates, candidate)
-				// we must scan all signature for all sections. DO NOT BREAK
-			}
-		}
-
-		pcHeader := findModuleInitPCHeader(elfScanner, sectionData)
-		if len(pcHeader) == 2 {
-			virtualOffset = (pcHeader[1] + sec.Addr) + pcHeader[0]
-		}
-
-		if virtualOffset != 0 {
-			if virtualOffset >= sec.Addr && virtualOffset <= (sec.Addr + sec.Size) {
-				// The virtual offset of moduledata is within this section
-				moduleDataOffset := virtualOffset - sec.Addr
-				pclntabPtr = binary.LittleEndian.Uint32(data[moduleDataOffset:][:4])
-				virtualOffset = 0
-			}
-			
-		}
-
-		if foundpcln && !symbol_method {
-			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
-			pclntab_idx := bytes.Index(data, pclntab_sym)
-			if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
-				var candidate PclntabCandidate
-				candidate.Pclntab = pclntab_sym
-				candidate.SecStart = uint64(sec.Addr)
-				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-				candidates = append(candidates, candidate)
-				symbol_method = true
-			}
-		}
-
-	}
-
-	// 4) Find the section containing the pclntab, get the offset, repair the magic, and add as a candidate
-	if pclntabPtr != 0 {
-		for _, sec := range f.elf.Sections {
-			data := f.elf.DataAfterSection(sec)
-			if uint64(pclntabPtr) >= sec.Addr && uint64(pclntabPtr) <= (sec.Addr + sec.Size) {
-				pclntabOffset := uint64(pclntabPtr) - sec.Addr
-
-				for _, sig := range pclntab_sigs {
 					var candidate PclntabCandidate
-
-					pclntab = append(sig, data[pclntabOffset+uint64(len(sig)):]...)
-					
 					candidate.Pclntab = pclntab
 
 					candidate.SecStart = uint64(sec.Addr)
-					candidate.PclntabVA = candidate.SecStart + uint64(pclntabOffset)
+					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 					candidates = append(candidates, candidate)
+					// we must scan all signature for all sections. DO NOT BREAK
 				}
-				break
+			}
+		} else {
+			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
+			pclntab_idx := bytes.Index(data, pclntab)
+			if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
+				var candidate PclntabCandidate
+				candidate.Pclntab = pclntab
+				candidate.SecStart = uint64(sec.Addr)
+				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+				candidates = append(candidates, candidate)
+			}
+		}
+
+		var moduleDataVA uint64 = 0
+
+		// TODO this scan needs to occur in both big and little endian mode
+		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
+		sigResult := findModuleInitPCHeader(data)
+		if sigResult != nil {
+			moduleDataVA = sigResult.moduleDataRVA + uint64(sec.Addr)
+		}
+
+		// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!
+		// 0x000000000069D0C0 E0 F6 5D 00 00 00 00 00 off_69D0C0      dq offset unk_5DF6E0    ; DATA XREF: runtime_SetFinalizer+119↑o
+		// 0x000000000069D0C0                                                                 ; runtime_scanstack+40B↑o ...
+		// 0x000000000069D0C8 40 F7 5D 00 00 00 00 00                 dq offset aInternalCpuIni ; "internal/cpu.Initialize"
+		// 0x000000000069D0D0 F0                                      db 0F0h
+		// 0x000000000069D0D1 BB                                      db 0BBh
+
+		// we don't know the endianess or arch, so we submit all combinations as candidates and sort them out later
+		// example: reads out ptr unk_5DF6E0
+		pclntabVARaw64, err := f.read_memory(moduleDataVA, 8) // assume 64bit
+		if err == nil {
+			stompedMagicCandidateLE := StompMagicCandidate{
+				binary.LittleEndian.Uint64(pclntabVARaw64),
+				moduleDataVA,
+				true,
+			}
+			stompedMagicCandidateBE := StompMagicCandidate{
+				binary.BigEndian.Uint64(pclntabVARaw64),
+				moduleDataVA,
+				false,
+			}
+			stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+		} else {
+			pclntabVARaw32, err := f.read_memory(moduleDataVA, 4) // assume 32bit
+			if err == nil {
+				stompedMagicCandidateLE := StompMagicCandidate{
+					uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
+					moduleDataVA,
+					true,
+				}
+				stompedMagicCandidateBE := StompMagicCandidate{
+					uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
+					moduleDataVA,
+					false,
+				}
+				stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+			}
+		}
+	}
+
+	if len(stompedmagic_candidates) != 0 {
+		for _, sec := range f.elf.Sections {
+			data := f.elf.DataAfterSection(sec)
+			for _, stompedMagicCandidate := range stompedmagic_candidates {
+				pclntab_va_candidate := stompedMagicCandidate.PclntabVa
+
+				if pclntab_va_candidate >= sec.Addr && pclntab_va_candidate < (sec.Addr+sec.Size) {
+					sec_offset := pclntab_va_candidate - sec.Addr
+					pclntab = data[sec_offset:]
+
+					if stompedMagicCandidate.LittleEndian {
+						for _, magicLE := range pclntab_sigs_le {
+							pclntab_copy := make([]byte, len(pclntab))
+							copy(pclntab_copy, pclntab)
+							copy(pclntab_copy, magicLE)
+
+							var candidate PclntabCandidate
+							candidate.StompMagicCandidateMeta = &stompedMagicCandidate
+							candidate.Pclntab = pclntab_copy
+							candidate.SecStart = uint64(sec.Addr)
+							candidate.PclntabVA = pclntab_va_candidate
+
+							candidates = append(candidates, candidate)
+						}
+					} else {
+						for _, magicBE := range pclntab_sigs_be {
+							pclntab_copy := make([]byte, len(pclntab))
+							copy(pclntab_copy, pclntab)
+							copy(pclntab_copy, magicBE)
+
+							var candidate PclntabCandidate
+							candidate.StompMagicCandidateMeta = &stompedMagicCandidate
+							candidate.Pclntab = pclntab_copy
+							candidate.SecStart = uint64(sec.Addr)
+							candidate.PclntabVA = pclntab_va_candidate
+
+							candidates = append(candidates, candidate)
+						}
+					}
+				}
 			}
 		}
 	}
@@ -274,11 +323,9 @@ scan:
 				secStart = sec.Addr
 
 				// optionally consult ignore list, to skip past previous (bad) scan results
-				if ignorelist != nil {
-					for _, ignore := range ignorelist {
-						if ignore == secStart+uint64(moduledata_idx) {
-							continue scan
-						}
+				for _, ignore := range ignorelist {
+					if ignore == secStart+uint64(moduledata_idx) {
+						continue scan
 					}
 				}
 

--- a/objfile/elf.go
+++ b/objfile/elf.go
@@ -104,10 +104,10 @@ func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	}
 
 	pclntab_sigs_be := [][]byte{
-		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), // big endian
-		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xF1\x00\x00"), // big endian
 		[]byte("\xFF\xFF\xFF\xF0\x00\x00"),
-		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"),
 	}
 
 	// 2) if not found, byte scan for it
@@ -155,6 +155,7 @@ func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 		// TODO this scan needs to occur in both big and little endian mode
 		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
+		// See the obfuscator 'garble' for an example of randomizing the pclntab magic
 		sigResults := findModuleInitPCHeader(data, sec.Addr)
 		for _, sigResult := range sigResults {
 			// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!

--- a/objfile/elf.go
+++ b/objfile/elf.go
@@ -125,6 +125,29 @@ ExitScan:
 					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
+            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+            //      for analysis purposes
+            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+            matches = findAllOccurrences(data, internal_sig)
+            for _, internal_idx := range matches {
+                if internal_idx != -1 {
+                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+                    for _, sig := range pclntab_sigs {
+                        pclntab = append(sig, data[pclntab_idx+6:]...)
+                    
+					    var candidate PclntabCandidate
+					    candidate.Pclntab = pclntab
+
+					    candidate.SecStart = uint64(sec.Addr)
+					    candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+					    candidates = append(candidates, candidate)
+                    }
+                }
+            }
 		} else {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)

--- a/objfile/elf.go
+++ b/objfile/elf.go
@@ -87,6 +87,8 @@ func (f *elfFile) symbols() ([]Sym, error) {
 }
 
 func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
+	imageBase, _ := f.loadAddress()
+
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
 	var pclntab []byte
@@ -157,47 +159,45 @@ func (f *elfFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 		// TODO this scan needs to occur in both big and little endian mode
 		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
-		sigResult := findModuleInitPCHeader(data)
-		if sigResult != nil {
-			moduleDataVA = sigResult.moduleDataRVA + uint64(sec.Addr)
-		}
+		sigResults := findModuleInitPCHeader(data, sec.Addr, imageBase)
+		for _, sigResult := range sigResults {
+			// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!
+			// 0x000000000069D0C0 E0 F6 5D 00 00 00 00 00 off_69D0C0      dq offset unk_5DF6E0    ; DATA XREF: runtime_SetFinalizer+119↑o
+			// 0x000000000069D0C0                                                                 ; runtime_scanstack+40B↑o ...
+			// 0x000000000069D0C8 40 F7 5D 00 00 00 00 00                 dq offset aInternalCpuIni ; "internal/cpu.Initialize"
+			// 0x000000000069D0D0 F0                                      db 0F0h
+			// 0x000000000069D0D1 BB                                      db 0BBh
 
-		// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!
-		// 0x000000000069D0C0 E0 F6 5D 00 00 00 00 00 off_69D0C0      dq offset unk_5DF6E0    ; DATA XREF: runtime_SetFinalizer+119↑o
-		// 0x000000000069D0C0                                                                 ; runtime_scanstack+40B↑o ...
-		// 0x000000000069D0C8 40 F7 5D 00 00 00 00 00                 dq offset aInternalCpuIni ; "internal/cpu.Initialize"
-		// 0x000000000069D0D0 F0                                      db 0F0h
-		// 0x000000000069D0D1 BB                                      db 0BBh
-
-		// we don't know the endianess or arch, so we submit all combinations as candidates and sort them out later
-		// example: reads out ptr unk_5DF6E0
-		pclntabVARaw64, err := f.read_memory(moduleDataVA, 8) // assume 64bit
-		if err == nil {
-			stompedMagicCandidateLE := StompMagicCandidate{
-				binary.LittleEndian.Uint64(pclntabVARaw64),
-				moduleDataVA,
-				true,
-			}
-			stompedMagicCandidateBE := StompMagicCandidate{
-				binary.BigEndian.Uint64(pclntabVARaw64),
-				moduleDataVA,
-				false,
-			}
-			stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
-		} else {
-			pclntabVARaw32, err := f.read_memory(moduleDataVA, 4) // assume 32bit
+			// we don't know the endianess or arch, so we submit all combinations as candidates and sort them out later
+			// example: reads out ptr unk_5DF6E0
+			pclntabVARaw64, err := f.read_memory(sigResult.moduleDataVA, 8) // assume 64bit
 			if err == nil {
 				stompedMagicCandidateLE := StompMagicCandidate{
-					uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
+					binary.LittleEndian.Uint64(pclntabVARaw64),
 					moduleDataVA,
 					true,
 				}
 				stompedMagicCandidateBE := StompMagicCandidate{
-					uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
+					binary.BigEndian.Uint64(pclntabVARaw64),
 					moduleDataVA,
 					false,
 				}
 				stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+			} else {
+				pclntabVARaw32, err := f.read_memory(moduleDataVA, 4) // assume 32bit
+				if err == nil {
+					stompedMagicCandidateLE := StompMagicCandidate{
+						uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
+						moduleDataVA,
+						true,
+					}
+					stompedMagicCandidateBE := StompMagicCandidate{
+						uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
+						moduleDataVA,
+						false,
+					}
+					stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+				}
 			}
 		}
 	}

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -124,15 +124,37 @@ ExitScan:
 		// malware can split the pclntab across multiple sections, re-merge
 		data := f.macho.DataAfterSection(sec)
 
-		if !foundpcln {
-			// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-			pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
-				[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
-			matches := findAllOccurrences(data, pclntab_sigs)
-			for _, pclntab_idx := range matches {
-				if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
-					pclntab = data[pclntab_idx:]
+		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
+		pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
+			[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
+		matches := findAllOccurrences(data, pclntab_sigs)
+		for _, pclntab_idx := range matches {
+			if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
+				pclntab = data[pclntab_idx:]
 
+				var candidate PclntabCandidate
+				candidate.Pclntab = pclntab
+
+				candidate.SecStart = uint64(sec.Addr)
+				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+				candidates = append(candidates, candidate)
+				// we must scan all signature for all sections. DO NOT BREAK
+			}
+		}
+		// 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+		//      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+		//      for analysis purposes
+		internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+		matches = findAllOccurrences(data, internal_sig)
+		for _, internal_idx := range matches {
+			if internal_idx != -1 {
+				// attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+				// the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+				pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+				for _, sig := range pclntab_sigs {
+					pclntab = append(sig, data[pclntab_idx+6:]...)
+				
 					var candidate PclntabCandidate
 					candidate.Pclntab = pclntab
 
@@ -140,33 +162,10 @@ ExitScan:
 					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 					candidates = append(candidates, candidate)
-					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
-            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
-            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
-            //      for analysis purposes
-            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
-            matches = findAllOccurrences(data, internal_sig)
-            for _, internal_idx := range matches {
-                if internal_idx != -1 {
-                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
-                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
-                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
-                    for _, sig := range pclntab_sigs {
-                        pclntab = append(sig, data[pclntab_idx+6:]...)
-                    
-					    var candidate PclntabCandidate
-					    candidate.Pclntab = pclntab
-
-					    candidate.SecStart = uint64(sec.Addr)
-					    candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-					    candidates = append(candidates, candidate)
-                    }
-                }
-            }
-		} else {
+		}
+		if foundpcln {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)
 			if pclntab_idx != -1 {

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -126,10 +126,10 @@ func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	}
 
 	pclntab_sigs_be := [][]byte{
-		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), // big endian
-		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xF1\x00\x00"), // big endian
 		[]byte("\xFF\xFF\xFF\xF0\x00\x00"),
-		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"),
 	}
 
 	// 2) if not found, byte scan for it
@@ -175,6 +175,7 @@ func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 		// TODO this scan needs to occur in both big and little endian mode
 		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
+		// See the obfuscator 'garble' for an example of randomizing the pclntab magic
 		sigResults := findModuleInitPCHeader(data, sec.Addr)
 		for _, sigResult := range sigResults {
 			// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -111,6 +111,8 @@ func (f *machoFile) symbols() ([]Sym, error) {
 func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
+	symbol_method := false
+	var pclntab_sym []byte
 	var pclntab []byte
 	if sect := f.macho.Section("__gopclntab"); sect != nil {
 		if pclntab, err = sect.Data(); err == nil {
@@ -119,14 +121,28 @@ func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	}
 
 	// 2) if not found, byte scan for it
-ExitScan:
+	var virtualOffset uint64 = 0
+	var pclntabPtr uint32 = 0
+	pclntab_sigs := [][]byte{
+		[]byte("\xF1\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xF0\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xFA\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),   
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xF0\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
+	}
 	for _, sec := range f.macho.Sections {
 		// malware can split the pclntab across multiple sections, re-merge
+
 		data := f.macho.DataAfterSection(sec)
+		sectionData, _ := sec.Data()
+		if uint64(len(data)) < sec.Size {
+			continue
+		}
 
 		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-		pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
-			[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
 		matches := findAllOccurrences(data, pclntab_sigs)
 		for _, pclntab_idx := range matches {
 			if pclntab_idx != -1 && pclntab_idx < int(sec.Size) {
@@ -142,42 +158,59 @@ ExitScan:
 				// we must scan all signature for all sections. DO NOT BREAK
 			}
 		}
-		// 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
-		//      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
-		//      for analysis purposes
-		internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
-		matches = findAllOccurrences(data, internal_sig)
-		for _, internal_idx := range matches {
-			if internal_idx != -1 {
-				// attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
-				// the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
-				pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
-				for _, sig := range pclntab_sigs {
-					pclntab = append(sig, data[pclntab_idx+6:]...)
-				
-					var candidate PclntabCandidate
-					candidate.Pclntab = pclntab
-
-					candidate.SecStart = uint64(sec.Addr)
-					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-					candidates = append(candidates, candidate)
-				}
-			}
+		
+		pcHeader := findModuleInitPCHeader(machoScanner, sectionData)
+		if len(pcHeader) == 2 {
+			virtualOffset = (pcHeader[1] + sec.Addr) + pcHeader[0]
 		}
-		if foundpcln {
+
+		if virtualOffset != 0 {
+			if virtualOffset >= sec.Addr && virtualOffset <= (sec.Addr + sec.Size) {
+				// The virtual offset of moduledata is within this section
+				moduleDataOffset := virtualOffset - sec.Addr
+				pclntabPtr = binary.LittleEndian.Uint32(data[moduleDataOffset:][:4])
+				virtualOffset = 0
+			}
+			
+		}
+
+		if foundpcln && !symbol_method {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
-			pclntab_idx := bytes.Index(data, pclntab)
+			pclntab_idx := bytes.Index(data, pclntab_sym)
 			if pclntab_idx != -1 {
 				var candidate PclntabCandidate
-				candidate.Pclntab = pclntab
+				candidate.Pclntab = pclntab_sym
 
 				candidate.SecStart = uint64(sec.Addr)
 				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 				candidates = append(candidates, candidate)
 
-				break ExitScan
+				symbol_method = true
+			}
+		}
+	}
+
+	// 4) Find the section containing the pclntab, get the offset, repair the magic, and add as a candidate
+	if pclntabPtr != 0 {
+		for _, sec := range f.macho.Sections {
+			data := f.macho.DataAfterSection(sec)
+			if uint64(pclntabPtr) >= sec.Addr && uint64(pclntabPtr) <= (sec.Addr + sec.Size) {
+				pclntabOffset := uint64(pclntabPtr) - sec.Addr
+
+				for _, sig := range pclntab_sigs {
+					var candidate PclntabCandidate
+
+					pclntab = append(sig, data[pclntabOffset+uint64(len(sig)):]...)
+					
+					candidate.Pclntab = pclntab
+
+					candidate.SecStart = uint64(sec.Addr)
+					candidate.PclntabVA = candidate.SecStart + uint64(pclntabOffset)
+
+					candidates = append(candidates, candidate)
+				}
+				break
 			}
 		}
 	}

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -143,6 +143,29 @@ ExitScan:
 					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
+            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+            //      for analysis purposes
+            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+            matches = findAllOccurrences(data, internal_sig)
+            for _, internal_idx := range matches {
+                if internal_idx != -1 {
+                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+                    for _, sig := range pclntab_sigs {
+                        pclntab = append(sig, data[pclntab_idx+6:]...)
+                    
+					    var candidate PclntabCandidate
+					    candidate.Pclntab = pclntab
+
+					    candidate.SecStart = uint64(sec.Addr)
+					    candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+					    candidates = append(candidates, candidate)
+                    }
+                }
+            }
 		} else {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)

--- a/objfile/macho.go
+++ b/objfile/macho.go
@@ -109,8 +109,6 @@ func (f *machoFile) symbols() ([]Sym, error) {
 }
 
 func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
-	imageBase, _ := f.loadAddress()
-
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
 	var pclntab []byte
@@ -175,11 +173,9 @@ func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 			}
 		}
 
-		var moduleDataVA uint64 = 0
-
 		// TODO this scan needs to occur in both big and little endian mode
 		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
-		sigResults := findModuleInitPCHeader(data, sec.Addr, imageBase)
+		sigResults := findModuleInitPCHeader(data, sec.Addr)
 		for _, sigResult := range sigResults {
 			// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!
 			// 0x000000000069D0C0 E0 F6 5D 00 00 00 00 00 off_69D0C0      dq offset unk_5DF6E0    ; DATA XREF: runtime_SetFinalizer+119↑o
@@ -194,32 +190,62 @@ func (f *machoFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 			if err == nil {
 				stompedMagicCandidateLE := StompMagicCandidate{
 					binary.LittleEndian.Uint64(pclntabVARaw64),
-					moduleDataVA,
+					sigResult.moduleDataVA,
 					true,
 				}
 				stompedMagicCandidateBE := StompMagicCandidate{
 					binary.BigEndian.Uint64(pclntabVARaw64),
-					moduleDataVA,
+					sigResult.moduleDataVA,
 					false,
 				}
 				stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
-			} else {
-				pclntabVARaw32, err := f.read_memory(moduleDataVA, 4) // assume 32bit
-				if err == nil {
-					stompedMagicCandidateLE := StompMagicCandidate{
-						uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
-						moduleDataVA,
-						true,
-					}
-					stompedMagicCandidateBE := StompMagicCandidate{
-						uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
-						moduleDataVA,
-						false,
-					}
-					stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+			}
+
+			pclntabVARaw32, err := f.read_memory(sigResult.moduleDataVA, 4) // assume 32bit
+			if err == nil {
+				stompedMagicCandidateLE := StompMagicCandidate{
+					uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
+					sigResult.moduleDataVA,
+					true,
 				}
+				stompedMagicCandidateBE := StompMagicCandidate{
+					uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
+					sigResult.moduleDataVA,
+					false,
+				}
+				stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
 			}
 		}
+	}
+
+	// even if we found the pclntab without signature scanning it may have a stomped magic. That would break parsing later! So, let's submit new candidates
+	// with all the possible magics to get at least one that hopefully parses correctly.
+	patched_magic_candidates := make([]PclntabCandidate, 0)
+	for _, candidate := range candidates {
+		has_some_valid_magic := false
+		for _, magic := range append(pclntab_sigs_le, pclntab_sigs_be...) {
+			if bytes.Equal(candidate.Pclntab, magic) {
+				has_some_valid_magic = true
+				break
+			}
+		}
+
+		if !has_some_valid_magic {
+			for _, magic := range append(pclntab_sigs_le, pclntab_sigs_be...) {
+				pclntab_copy := make([]byte, len(candidate.Pclntab))
+				copy(pclntab_copy, candidate.Pclntab)
+				copy(pclntab_copy, magic)
+
+				new_candidate := candidate
+				new_candidate.Pclntab = pclntab_copy
+				patched_magic_candidates = append(patched_magic_candidates, new_candidate)
+				candidate.Pclntab = pclntab_copy
+			}
+		}
+	}
+
+	if len(patched_magic_candidates) > 0 {
+		candidates = patched_magic_candidates
 	}
 
 	if len(stompedmagic_candidates) != 0 {

--- a/objfile/objfile.go
+++ b/objfile/objfile.go
@@ -1501,7 +1501,7 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 			}
 
 			structDef := "type struct {"
-			if *&_type.flags&tflagNamed != 0 {
+			if _type.flags&tflagNamed != 0 {
 				structDef = fmt.Sprintf("type %s struct {", _type.Str)
 			}
 

--- a/objfile/objfile.go
+++ b/objfile/objfile.go
@@ -22,12 +22,19 @@ import (
 	"github.com/mandiant/GoReSym/debug/gosym"
 )
 
+type StompMagicCandidate struct {
+	PclntabVa             uint64
+	SuspectedModuleDataVa uint64
+	LittleEndian          bool
+}
+
 type PclntabCandidate struct {
-	SecStart      uint64
-	PclntabVA     uint64
-	Pclntab       []byte
-	Symtab        []byte // optional
-	ParsedPclntab *gosym.Table
+	SecStart                uint64
+	PclntabVA               uint64
+	StompMagicCandidateMeta *StompMagicCandidate // some search modes might optimistically try to find moduledata or guess endianess, these hints must match the found moduleData VA later to be considered good candidate
+	Pclntab                 []byte
+	Symtab                  []byte // optional
+	ParsedPclntab           *gosym.Table
 }
 
 type rawFile interface {
@@ -241,7 +248,6 @@ func (e *Entry) PCLineTable(versionOverride string, knownGoTextBase uint64) ([]P
 
 func (e *Entry) ModuleDataTable(pclntabVA uint64, runtimeVersion string, version string, is64bit bool, littleendian bool) (secStart uint64, moduleData *ModuleData, err error) {
 	moduleData = &ModuleData{}
-
 	// Major version only, 1.15.5 -> 1.15
 	parts := strings.Split(runtimeVersion, ".")
 	if len(parts) >= 2 {

--- a/objfile/pe.go
+++ b/objfile/pe.go
@@ -140,7 +140,9 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
+	symbol_method := false
 	var pclntab []byte
+	var pclntab_sym []byte
 
 	if pclntab, err = loadPETable(f.pe, "runtime.pclntab", "runtime.epclntab"); err == nil {
 		foundpcln = true
@@ -154,14 +156,29 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	}
 
 	// 2) if not found, byte scan for it
-ExitScan:
+	var virtualOffset uint64 = 0
+	var pclntabPtr uint32 = 0
+	pclntab_sigs := [][]byte{
+		[]byte("\xF1\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xF0\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xFA\xFF\xFF\xFF\x00\x00"),
+		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),   
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xF0\x00\x00"), 
+		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
+	}
 	for _, sec := range f.pe.Sections {
-		// malware can split the pclntab across multiple sections, re-merge
 		data := f.pe.DataAfterSection(sec)
+		sectionData, _ := sec.Data()
+		if uint32(len(data)) < sec.Size {
+			continue
+		}
 
+
+		// 2.1 original byte scan for magic
+		// malware can split the pclntab across multiple sections, re-merge
 		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-		pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
-			[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
 		matches := findAllOccurrences(data, pclntab_sigs)
 		for _, pclntab_idx := range matches {
 			if pclntab_idx != -1 {
@@ -177,41 +194,58 @@ ExitScan:
 				// we must scan all signature for all sections. DO NOT BREAK
 			}
 		}
-		// 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
-		//      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
-		//      for analysis purposes
-		internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
-		matches = findAllOccurrences(data, internal_sig)
-		for _, internal_idx := range matches {
-			if internal_idx != -1 {
-				// attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
-				// the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
-				pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
-				for _, sig := range pclntab_sigs {
-					pclntab = append(sig, data[pclntab_idx+6:]...)
-				
-					var candidate PclntabCandidate
-					candidate.Pclntab = pclntab
 
-					candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
-					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-					candidates = append(candidates, candidate)
-				}
-			}
+		pcHeader := findModuleInitPCHeader(peScanner, sectionData)
+		if len(pcHeader) == 2 {
+			virtualOffset = (pcHeader[1] + uint64(sec.VirtualAddress)) + pcHeader[0]
 		}
-		if foundpcln {
+
+		if virtualOffset != 0 {
+			if virtualOffset >= uint64(sec.VirtualAddress) && virtualOffset <= uint64(sec.VirtualAddress + sec.Size) {
+				// The virtual offset of moduledata is within this section
+				moduleDataOffset := virtualOffset - uint64(sec.SectionHeader.VirtualAddress)
+				pclntabPtr = binary.LittleEndian.Uint32(data[moduleDataOffset:][:4])
+				virtualOffset = 0
+			}
+			
+		}
+
+		if foundpcln && !symbol_method {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
-			pclntab_idx := bytes.Index(data, pclntab)
+			pclntab_idx := bytes.Index(data, pclntab_sym)
 			if pclntab_idx != -1 {
 				var candidate PclntabCandidate
-				candidate.Pclntab = pclntab
+				candidate.Pclntab = pclntab_sym
 
 				candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
 				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 				candidates = append(candidates, candidate)
-				break ExitScan
+				symbol_method = true
+			}
+		}
+	}
+
+	// 4) Find the section containing the pclntab, get the offset, repair the magic, and add as a candidate
+	if pclntabPtr != 0 {
+		for _, sec := range f.pe.Sections {
+			data := f.pe.DataAfterSection(sec)
+			if uint64(pclntabPtr) >= uint64(sec.VirtualAddress) && uint64(pclntabPtr) <= uint64(sec.VirtualAddress + sec.SectionHeader.Size) {
+				pclntabOffset := uint64(pclntabPtr) - uint64(sec.VirtualAddress) - imageBase
+
+				for _, sig := range pclntab_sigs {
+					var candidate PclntabCandidate
+
+					pclntab = append(sig, data[pclntabOffset+uint64(len(sig)):]...)
+					
+					candidate.Pclntab = pclntab
+
+					candidate.SecStart = uint64(sec.VirtualAddress)
+					candidate.PclntabVA = candidate.SecStart + uint64(pclntabOffset)
+
+					candidates = append(candidates, candidate)
+				}
+				break
 			}
 		}
 	}

--- a/objfile/pe.go
+++ b/objfile/pe.go
@@ -159,15 +159,37 @@ ExitScan:
 		// malware can split the pclntab across multiple sections, re-merge
 		data := f.pe.DataAfterSection(sec)
 
-		if !foundpcln {
-			// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-			pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
-				[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
-			matches := findAllOccurrences(data, pclntab_sigs)
-			for _, pclntab_idx := range matches {
-				if pclntab_idx != -1 {
-					pclntab = data[pclntab_idx:]
+		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
+		pclntab_sigs := [][]byte{[]byte("\xFB\xFF\xFF\xFF\x00\x00"), []byte("\xFA\xFF\xFF\xFF\x00\x00"), []byte("\xF0\xFF\xFF\xFF\x00\x00"), []byte("\xF1\xFF\xFF\xFF\x00\x00"),
+			[]byte("\xFF\xFF\xFF\xFB\x00\x00"), []byte("\xFF\xFF\xFF\xFA\x00\x00"), []byte("\xFF\xFF\xFF\xF0\x00\x00"), []byte("\xFF\xFF\xFF\xF1\x00\x00")}
+		matches := findAllOccurrences(data, pclntab_sigs)
+		for _, pclntab_idx := range matches {
+			if pclntab_idx != -1 {
+				pclntab = data[pclntab_idx:]
 
+				var candidate PclntabCandidate
+				candidate.Pclntab = pclntab
+
+				candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
+				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+				candidates = append(candidates, candidate)
+				// we must scan all signature for all sections. DO NOT BREAK
+			}
+		}
+		// 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
+		//      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
+		//      for analysis purposes
+		internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
+		matches = findAllOccurrences(data, internal_sig)
+		for _, internal_idx := range matches {
+			if internal_idx != -1 {
+				// attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
+				// the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
+				pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
+				for _, sig := range pclntab_sigs {
+					pclntab = append(sig, data[pclntab_idx+6:]...)
+				
 					var candidate PclntabCandidate
 					candidate.Pclntab = pclntab
 
@@ -175,33 +197,10 @@ ExitScan:
 					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 					candidates = append(candidates, candidate)
-					// we must scan all signature for all sections. DO NOT BREAK
 				}
 			}
-            // 2.1) Also try to guess the location of the pclntab by looking for the first runtime package (internal/cpu.Initialize)
-            //      This is a bit of a hack for some obfuscated/mangled binaries, but it works in most cases for repairing the pclntab enough to restore symbols
-            //      for analysis purposes
-            internal_sig := [][]byte{[]byte("internal/cpu.Initialize")}
-            matches = findAllOccurrences(data, internal_sig)
-            for _, internal_idx := range matches {
-                if internal_idx != -1 {
-                    // attempt to guess the location of the start of the pclntab by looking 96 bytes before the first runtime package
-                    // the location is also floored to the nearest 16 byte boundary, since this appears to be the most common alignment
-                    pclntab_idx := ((internal_idx / 0x10 * 0x10) - 96)
-                    for _, sig := range pclntab_sigs {
-                        pclntab = append(sig, data[pclntab_idx+6:]...)
-                    
-                        var candidate PclntabCandidate
-                        candidate.Pclntab = pclntab
-
-                        candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
-                        candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-                        candidates = append(candidates, candidate)
-                    }
-                }
-            }
-		} else {
+		}
+		if foundpcln {
 			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
 			pclntab_idx := bytes.Index(data, pclntab)
 			if pclntab_idx != -1 {

--- a/objfile/pe.go
+++ b/objfile/pe.go
@@ -161,10 +161,10 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	}
 
 	pclntab_sigs_be := [][]byte{
-		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), // big endian
-		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xF1\x00\x00"), // big endian
 		[]byte("\xFF\xFF\xFF\xF0\x00\x00"),
-		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"),
 	}
 
 	// 2) if not found, byte scan for it
@@ -210,6 +210,7 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 		// TODO this scan needs to occur in both big and little endian mode
 		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
+		// See the obfuscator 'garble' for an example of randomizing the pclntab magic
 		sigResults := findModuleInitPCHeader(data, uint64(sec.VirtualAddress)+imageBase)
 		for _, sigResult := range sigResults {
 			// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!

--- a/objfile/pe.go
+++ b/objfile/pe.go
@@ -140,9 +140,7 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 
 	// 1) Locate pclntab via symbols (standard way)
 	foundpcln := false
-	symbol_method := false
 	var pclntab []byte
-	var pclntab_sym []byte
 
 	if pclntab, err = loadPETable(f.pe, "runtime.pclntab", "runtime.epclntab"); err == nil {
 		foundpcln = true
@@ -155,35 +153,51 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 		}
 	}
 
-	// 2) if not found, byte scan for it
-	var virtualOffset uint64 = 0
-	var pclntabPtr uint32 = 0
-	pclntab_sigs := [][]byte{
-		[]byte("\xF1\xFF\xFF\xFF\x00\x00"),
+	pclntab_sigs_le := [][]byte{
+		[]byte("\xF1\xFF\xFF\xFF\x00\x00"), // little endian
 		[]byte("\xF0\xFF\xFF\xFF\x00\x00"),
 		[]byte("\xFA\xFF\xFF\xFF\x00\x00"),
-		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),   
-		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), 
-		[]byte("\xFF\xFF\xFF\xFA\x00\x00"), 
-		[]byte("\xFF\xFF\xFF\xF0\x00\x00"), 
+		[]byte("\xFB\xFF\xFF\xFF\x00\x00"),
+	}
+
+	pclntab_sigs_be := [][]byte{
+		[]byte("\xFF\xFF\xFF\xFB\x00\x00"), // big endian
+		[]byte("\xFF\xFF\xFF\xFA\x00\x00"),
+		[]byte("\xFF\xFF\xFF\xF0\x00\x00"),
 		[]byte("\xFF\xFF\xFF\xF1\x00\x00"),
 	}
+
+	// 2) if not found, byte scan for it
+	pclntab_sigs := append(pclntab_sigs_le, pclntab_sigs_be...)
+
+	// candidate array for method 4 of scanning
+	var stompedmagic_candidates []StompMagicCandidate = make([]StompMagicCandidate, 0)
+
+	// 2) if not found, byte scan for it
 	for _, sec := range f.pe.Sections {
-		data := f.pe.DataAfterSection(sec)
-		sectionData, _ := sec.Data()
-		if uint32(len(data)) < sec.Size {
-			continue
-		}
-
-
-		// 2.1 original byte scan for magic
 		// malware can split the pclntab across multiple sections, re-merge
-		// https://github.com/golang/go/blob/2cb9042dc2d5fdf6013305a077d013dbbfbaac06/src/debug/gosym/pclntab.go#L172
-		matches := findAllOccurrences(data, pclntab_sigs)
-		for _, pclntab_idx := range matches {
-			if pclntab_idx != -1 {
-				pclntab = data[pclntab_idx:]
+		data := f.pe.DataAfterSection(sec)
 
+		if !foundpcln {
+			matches := findAllOccurrences(data, pclntab_sigs)
+			for _, pclntab_idx := range matches {
+				if pclntab_idx != -1 {
+					pclntab = data[pclntab_idx:]
+
+					var candidate PclntabCandidate
+					candidate.Pclntab = pclntab
+
+					candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
+					candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
+
+					candidates = append(candidates, candidate)
+					// we must scan all signature for all sections. DO NOT BREAK
+				}
+			}
+		} else {
+			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
+			pclntab_idx := bytes.Index(data, pclntab)
+			if pclntab_idx != -1 {
 				var candidate PclntabCandidate
 				candidate.Pclntab = pclntab
 
@@ -191,61 +205,99 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
 
 				candidates = append(candidates, candidate)
-				// we must scan all signature for all sections. DO NOT BREAK
 			}
 		}
 
-		pcHeader := findModuleInitPCHeader(peScanner, sectionData)
-		if len(pcHeader) == 2 {
-			virtualOffset = (pcHeader[1] + uint64(sec.VirtualAddress)) + pcHeader[0]
+		var moduleDataVA uint64 = 0
+
+		// TODO this scan needs to occur in both big and little endian mode
+		// 4) Always try this other way! Sometimes the pclntab magic is stomped as well so our byte OR symbol location fail. Byte scan for the moduledata, use that to find the pclntab instead, fix up magic with all combinations.
+		sigResult := findModuleInitPCHeader(data)
+		if sigResult != nil {
+			moduleDataVA = sigResult.moduleDataRVA + imageBase + uint64(sec.VirtualAddress)
 		}
 
-		if virtualOffset != 0 {
-			if virtualOffset >= uint64(sec.VirtualAddress) && virtualOffset <= uint64(sec.VirtualAddress + sec.Size) {
-				// The virtual offset of moduledata is within this section
-				moduleDataOffset := virtualOffset - uint64(sec.SectionHeader.VirtualAddress)
-				pclntabPtr = binary.LittleEndian.Uint32(data[moduleDataOffset:][:4])
-				virtualOffset = 0
+		// example: off_69D0C0 is the moduleData we found via our scan, the first ptr unk_5DF6E0, is the pclntab!
+		// 0x000000000069D0C0 E0 F6 5D 00 00 00 00 00 off_69D0C0      dq offset unk_5DF6E0    ; DATA XREF: runtime_SetFinalizer+119↑o
+		// 0x000000000069D0C0                                                                 ; runtime_scanstack+40B↑o ...
+		// 0x000000000069D0C8 40 F7 5D 00 00 00 00 00                 dq offset aInternalCpuIni ; "internal/cpu.Initialize"
+		// 0x000000000069D0D0 F0                                      db 0F0h
+		// 0x000000000069D0D1 BB                                      db 0BBh
+
+		// we don't know the endianess or arch, so we submit all combinations as candidates and sort them out later
+		// example: reads out ptr unk_5DF6E0
+		pclntabVARaw64, err := f.read_memory(moduleDataVA, 8) // assume 64bit
+		if err == nil {
+			stompedMagicCandidateLE := StompMagicCandidate{
+				binary.LittleEndian.Uint64(pclntabVARaw64),
+				moduleDataVA,
+				true,
 			}
-			
-		}
-
-		if foundpcln && !symbol_method {
-			// 3) if we found it earlier, figure out which section base to return (might be wrong for packed things)
-			pclntab_idx := bytes.Index(data, pclntab_sym)
-			if pclntab_idx != -1 {
-				var candidate PclntabCandidate
-				candidate.Pclntab = pclntab_sym
-
-				candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
-				candidate.PclntabVA = candidate.SecStart + uint64(pclntab_idx)
-
-				candidates = append(candidates, candidate)
-				symbol_method = true
+			stompedMagicCandidateBE := StompMagicCandidate{
+				binary.BigEndian.Uint64(pclntabVARaw64),
+				moduleDataVA,
+				false,
+			}
+			stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
+		} else {
+			pclntabVARaw32, err := f.read_memory(moduleDataVA, 4) // assume 32bit
+			if err == nil {
+				stompedMagicCandidateLE := StompMagicCandidate{
+					uint64(binary.LittleEndian.Uint32(pclntabVARaw32)),
+					moduleDataVA,
+					true,
+				}
+				stompedMagicCandidateBE := StompMagicCandidate{
+					uint64(binary.BigEndian.Uint32(pclntabVARaw32)),
+					moduleDataVA,
+					false,
+				}
+				stompedmagic_candidates = append(stompedmagic_candidates, stompedMagicCandidateLE, stompedMagicCandidateBE)
 			}
 		}
 	}
 
-	// 4) Find the section containing the pclntab, get the offset, repair the magic, and add as a candidate
-	if pclntabPtr != 0 {
+	if len(stompedmagic_candidates) != 0 {
 		for _, sec := range f.pe.Sections {
+			// malware can split the pclntab across multiple sections, re-merge
 			data := f.pe.DataAfterSection(sec)
-			if uint64(pclntabPtr) >= uint64(sec.VirtualAddress) && uint64(pclntabPtr) <= uint64(sec.VirtualAddress + sec.SectionHeader.Size) {
-				pclntabOffset := uint64(pclntabPtr) - uint64(sec.VirtualAddress) - imageBase
+			for _, stompedMagicCandidate := range stompedmagic_candidates {
+				pclntab_va_candidate := stompedMagicCandidate.PclntabVa
 
-				for _, sig := range pclntab_sigs {
-					var candidate PclntabCandidate
+				if pclntab_va_candidate >= (imageBase+uint64(sec.VirtualAddress)) && pclntab_va_candidate < (imageBase+uint64(sec.VirtualAddress)+uint64(sec.Size)) {
+					sec_offset := pclntab_va_candidate - (imageBase + uint64(sec.VirtualAddress))
+					pclntab = data[sec_offset:]
 
-					pclntab = append(sig, data[pclntabOffset+uint64(len(sig)):]...)
-					
-					candidate.Pclntab = pclntab
+					if stompedMagicCandidate.LittleEndian {
+						for _, magicLE := range pclntab_sigs_le {
+							pclntab_copy := make([]byte, len(pclntab))
+							copy(pclntab_copy, pclntab)
+							copy(pclntab_copy, magicLE)
 
-					candidate.SecStart = uint64(sec.VirtualAddress)
-					candidate.PclntabVA = candidate.SecStart + uint64(pclntabOffset)
+							var candidate PclntabCandidate
+							candidate.StompMagicCandidateMeta = &stompedMagicCandidate
+							candidate.Pclntab = pclntab_copy
+							candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
+							candidate.PclntabVA = pclntab_va_candidate
 
-					candidates = append(candidates, candidate)
+							candidates = append(candidates, candidate)
+						}
+					} else {
+						for _, magicBE := range pclntab_sigs_be {
+							pclntab_copy := make([]byte, len(pclntab))
+							copy(pclntab_copy, pclntab)
+							copy(pclntab_copy, magicBE)
+
+							var candidate PclntabCandidate
+							candidate.StompMagicCandidateMeta = &stompedMagicCandidate
+							candidate.Pclntab = pclntab_copy
+							candidate.SecStart = imageBase + uint64(sec.VirtualAddress)
+							candidate.PclntabVA = pclntab_va_candidate
+
+							candidates = append(candidates, candidate)
+						}
+					}
 				}
-				break
 			}
 		}
 	}

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -28,7 +28,11 @@ type SignatureMatch struct {
 	moduleDataVA uint64
 }
 
-var x64sig = signatureModuleDataInitx64{21, 25, []byte("48 8D 05 ?? ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 89 44 24 ?? 48 8D 0D ?? ?? ?? ?? EB 0D")}
+// .text:000000000044D80A 48 8D 0D 8F DA 26 00                    lea     rcx, runtime_firstmoduledata
+// .text:000000000044D811 EB 0D                                   jmp     short loc_44D820
+// .text:000000000044D813 48 8B 89 30 02 00 00                    mov     rcx, [rcx+230h]
+// .text:000000000044D81A 66 0F 1F 44 00 00                       nop     word ptr [rax+rax+00h]    <- always seems to be present
+var x64sig = signatureModuleDataInitx64{3, 7, []byte("48 8D 0? ?? ?? ?? ?? EB ?? 48 8? 8? ?? 02 00 00 66 0F 1F 44 00 00")}
 
 // .text:00438A94 8D 05 60 49 6A 00                       lea     eax, off_6A4960
 // .text:00438A9A EB 1A                                   jmp     short loc_438AB6
@@ -97,7 +101,7 @@ func findPattern(data []byte, signature []byte, callback func(uint64) []Signatur
 	return matches
 }
 
-func findModuleInitPCHeader(data []byte, sectionBase uint64, imageBase uint64) []SignatureMatch {
+func findModuleInitPCHeader(data []byte, sectionBase uint64) []SignatureMatch {
 	var matches []SignatureMatch = make([]SignatureMatch, 0)
 
 	// x64 scan

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -68,7 +68,7 @@ func findPattern(data []byte, signature []byte, callback func(uint64) []Signatur
 	patternSize := getPatternSize(signature)
 	for i := range data {
 		sigIdx := 0
-		for sigIdx < patternSize {
+		for sigIdx < patternSize && i+sigIdx < len(data) {
 			sigPatIdx := sigIdx * 3
 			sigHi := getBits(signature[sigPatIdx:][0]) << 4
 			sigLo := getBits(signature[sigPatIdx:][1])

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -1,52 +1,33 @@
-
 package objfile
 
 import (
 	"encoding/binary"
 )
 
-type signatureMetaData struct {
-	PCHeaderPtrLoc		int        // offset in signature to the location of the pointer to the PCHeader
-	targetInstIdx		int        // offset in signature to the instruction after the PCHeader pointer
-	signature			[]byte     // signature to search for (0x90 is wildcard)
+type signatureModuleDataInit struct {
+	moduleDataPtrLoc       uint8  // offset in signature to the location of the pointer to the PCHeader
+	moduleDataPtrOffsetLoc int    // Ptr is a relative ptr, we need to include the instruction length + next instruction IP to resolve final VA
+	signature              []byte // signature to search for (0x90 is wildcard)
 }
 
-var peSigs = []signatureMetaData {
+type SignatureMatch struct {
+	moduleDataRVA uint64 // caller is responsible for adding the section base to this RVA
+}
+
+// TODO: Support more architectures in this mode - will involve big endian support for at least ppc64 (just one pointer read in the scanner here)
+var x64sig = []signatureModuleDataInit{
 	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
 }
 
-var elfSigs = []signatureMetaData {
-	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
-}
-
-var machoSigs = []signatureMetaData {
-	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
-}
-
-
-const (
-	peScanner	    uint32 = 0x1
-	elfScanner 	    uint32 = 0x2
-	machoScanner	uint32 = 0x3
-)
-
-func findModuleInitPCHeader(os uint32, data []byte) []uint64 {
-	var sigs []signatureMetaData
-	switch os {
-	case 1:
-		sigs = peSigs
-	case 2:
-		sigs = elfSigs
-	case 3:
-		sigs = machoSigs
-	}
+func findModuleInitPCHeader(data []byte) *SignatureMatch {
+	var sigs []signatureModuleDataInit = x64sig
 
 	for _, sigMeta := range sigs {
 		var sigIdx = 0
 		var isMatch = false
-		var sigPtr = 0
+		var sigPtr = uint64(0)
 		for idx := range data {
-			if len(data[idx:]) < len(sigMeta.signature) - sigIdx {
+			if len(data[idx:]) < len(sigMeta.signature)-sigIdx {
 				break
 			}
 
@@ -63,20 +44,30 @@ func findModuleInitPCHeader(os uint32, data []byte) []uint64 {
 				continue
 			}
 
-			// store start index for signature attempt when it is a good signature 
+			// store start index for signature attempt when it is a good signature
 			if !isMatch {
-				sigPtr = idx
+				sigPtr = uint64(idx)
 				isMatch = true
 			}
 
 			if sigIdx == len(sigMeta.signature)-1 {
-				// found a match, return on first match
-                moduleData := binary.LittleEndian.Uint32(data[sigPtr+sigMeta.PCHeaderPtrLoc:][:4])
-				return []uint64{uint64(moduleData), uint64(sigPtr)+uint64(sigMeta.targetInstIdx)}
+				// this is the pointer offset stored in the instruction
+				// 0x44E06A:       48 8D 0D 4F F0 24 00 lea     rcx, off_69D0C0 (result: 0x24f04f)
+				moduleDataPtrOffset := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(sigMeta.moduleDataPtrLoc):][:4]))
+
+				// typically you'd now do 0x44E06A + 7 = nextInstruction then nextInstruction + 0x24f04f = final VA. But we don't know the section base yet.
+				// Taking our equation nextInstruction + 0x24f04f = final VA, we can rewrite: (sectionBase + offsetNextInstruction) + 0x24f04f = final VA
+				// offsetNextInstruction is the same as our sigPtr + some X which we know based on the signature we wrote.
+				// We therefore finally do moduleDataIpOffset = sigPtr + PCHeaderPtrOffset, sectionBase + moduleDataIpOffset + 0x24f04f = final VA
+				// and that gives us an RVA relative to the sectionBase, which we just add back in whatever calls this function
+				// it's actually simple, just confusing :)
+				moduleDataIpOffset := uint64(sigPtr) + uint64(sigMeta.moduleDataPtrOffsetLoc)
+				return &SignatureMatch{
+					moduleDataPtrOffset + moduleDataIpOffset,
+				}
 			}
 		}
 	}
 
-	return []uint64{}
-
+	return nil
 }

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -21,7 +21,7 @@ type SignatureMatch struct {
 }
 
 // TODO: Support more architectures in this mode - will involve big endian support for at least ppc64 (just one pointer read in the scanner here)
-var x64sig = signatureModuleDataInitx86_x64{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")}
+var x64sig = signatureModuleDataInitx86_x64{21, 25, []byte("48 8D 05 ?? ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 89 44 24 ?? 48 8D 0D ?? ?? ?? ?? EB 0D")}
 
 // 0x0000000000061a74:  3C 80 00 2C    lis  r4, 0x2c       // moduledata
 // 0x0000000000061a78:  38 84 80 00    addi r4, r4, 0x8000  // moduledata ((0x2c << 16) + 0x8000)
@@ -29,31 +29,51 @@ var x64sig = signatureModuleDataInitx86_x64{21, 25, []byte("\x48\x8D\x05\x90\x90
 // 0x0000000000061a80:  E8 84 02 30    ld   r4, 0x230(r4)
 // 0x0000000000061a84:  7C 24 00 00    cmpd r4, r0
 // 0x0000000000061a88:  41 82 01 A8    beq  0x61c30
-var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("\x90\x80\x00\x2C\x90\x90\x80\x00\x48\x90\x90\x08\x90\x90\x02\x30\x7C\x90\x00\x00\x41\x82\x90\x90")}
+var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("3? 80 00 2C 3? ?? 80 00 48 ?? ?? 08 E? ?? 02 30 7C ?? 00 00 41 82 ?? ??")}
 
+func getPatternSize(signature []byte) int {
+	// c = 2 * b + (b - 1) . 2 chars per byte + b - 1 spaces between
+	return (len(signature) + 1) / 3
+}
+
+func getBits(x byte) byte {
+	if x >= '0' && x <= '9' {
+		return x - '0'
+	} else {
+		return (x & 0xDF) - 'A' + 0xa
+	}
+}
+
+// Pattern must have a space per byte, use ? as wildcard for nibbles, and be uppercase ascii text without the 0x or /x prefix
 func findPattern(data []byte, signature []byte, callback func(uint64) []SignatureMatch) []SignatureMatch {
 	var matches []SignatureMatch = make([]SignatureMatch, 0)
-	var sigIdx = uint64(0)
+	patternSize := getPatternSize(signature)
+	for i := range data {
+		sigIdx := 0
+		for sigIdx < patternSize {
+			sigPatIdx := sigIdx * 3
+			sigHi := getBits(signature[sigPatIdx:][0]) << 4
+			sigLo := getBits(signature[sigPatIdx:][1])
+			datByt := data[i+sigIdx:][0]
 
-	for idx := range data {
-		if uint64(len(data[idx:])) < uint64(len(signature))-sigIdx {
-			break
+			// check for ex: A?
+			if signature[sigPatIdx+1] == '?' {
+				sigLo = datByt & 0xF
+			}
+
+			if signature[sigPatIdx] == '?' {
+				sigHi = datByt & 0xF0
+			}
+
+			if datByt != (sigHi | sigLo) {
+				break
+			}
+
+			sigIdx += 1
 		}
 
-		if signature[sigIdx] == 0x90 {
-			// nop instruction is considered "wildcard"
-			sigIdx += 1
-		} else if signature[sigIdx] == data[idx] {
-			// Byte in signature is equal to position in data
-			sigIdx += 1
-		} else {
-			sigIdx = 0
-			continue
-		}
-
-		if sigIdx == uint64(len(signature))-1 {
-			matches = append(matches, callback(uint64(idx-len(signature)+2))...)
-			sigIdx = 0 // reset, scan rest of data for other matches
+		if sigIdx >= patternSize {
+			matches = append(matches, callback(uint64(i))...)
 		}
 	}
 	return matches

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -4,70 +4,92 @@ import (
 	"encoding/binary"
 )
 
-type signatureModuleDataInit struct {
+type signatureModuleDataInitx86_x64 struct {
 	moduleDataPtrLoc       uint8  // offset in signature to the location of the pointer to the PCHeader
-	moduleDataPtrOffsetLoc int    // Ptr is a relative ptr, we need to include the instruction length + next instruction IP to resolve final VA
+	moduleDataPtrOffsetLoc uint8  // Ptr is a relative ptr, we need to include the instruction length + next instruction IP to resolve final VA
 	signature              []byte // signature to search for (0x90 is wildcard)
 }
 
+type signatureModuleDataInitPPC struct {
+	moduleDataPtrHi uint8
+	moduleDataPtrLo uint8
+	signature       []byte // signature to search for (0x90 is wildcard)
+}
+
 type SignatureMatch struct {
-	moduleDataRVA uint64 // caller is responsible for adding the section base to this RVA
+	moduleDataVA uint64
 }
 
 // TODO: Support more architectures in this mode - will involve big endian support for at least ppc64 (just one pointer read in the scanner here)
-var x64sig = []signatureModuleDataInit{
-	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
-}
+var x64sig = signatureModuleDataInitx86_x64{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")}
 
-func findModuleInitPCHeader(data []byte) *SignatureMatch {
-	var sigs []signatureModuleDataInit = x64sig
+// 0x0000000000061a74:  3C 80 00 2C    lis  r4, 0x2c       // moduledata
+// 0x0000000000061a78:  38 84 80 00    addi r4, r4, 0x8000  // moduledata ((0x2c << 16) + 0x8000)
+// 0x0000000000061a7c:  48 00 00 08    b    0x61a84
+// 0x0000000000061a80:  E8 84 02 30    ld   r4, 0x230(r4)
+// 0x0000000000061a84:  7C 24 00 00    cmpd r4, r0
+// 0x0000000000061a88:  41 82 01 A8    beq  0x61c30
+var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("\x90\x80\x00\x2C\x90\x90\x80\x00\x48\x90\x90\x08\x90\x90\x02\x30\x7C\x90\x00\x00\x41\x82\x90\x90")}
 
-	for _, sigMeta := range sigs {
-		var sigIdx = 0
-		var isMatch = false
-		var sigPtr = uint64(0)
-		for idx := range data {
-			if len(data[idx:]) < len(sigMeta.signature)-sigIdx {
-				break
-			}
+func findPattern(data []byte, signature []byte, callback func(uint64) []SignatureMatch) []SignatureMatch {
+	var matches []SignatureMatch = make([]SignatureMatch, 0)
+	var sigIdx = uint64(0)
 
-			if sigMeta.signature[sigIdx] == 0x90 {
-				// nop instruction is considered "wildcard"
-				sigIdx += 1
-			} else if sigMeta.signature[sigIdx] == data[idx] {
-				// Byte in signature is equal to position in data
-				sigIdx += 1
-			} else {
-				// No match
-				isMatch = false
-				sigIdx = 0
-				continue
-			}
+	for idx := range data {
+		if uint64(len(data[idx:])) < uint64(len(signature))-sigIdx {
+			break
+		}
 
-			// store start index for signature attempt when it is a good signature
-			if !isMatch {
-				sigPtr = uint64(idx)
-				isMatch = true
-			}
+		if signature[sigIdx] == 0x90 {
+			// nop instruction is considered "wildcard"
+			sigIdx += 1
+		} else if signature[sigIdx] == data[idx] {
+			// Byte in signature is equal to position in data
+			sigIdx += 1
+		} else {
+			sigIdx = 0
+			continue
+		}
 
-			if sigIdx == len(sigMeta.signature)-1 {
-				// this is the pointer offset stored in the instruction
-				// 0x44E06A:       48 8D 0D 4F F0 24 00 lea     rcx, off_69D0C0 (result: 0x24f04f)
-				moduleDataPtrOffset := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(sigMeta.moduleDataPtrLoc):][:4]))
-
-				// typically you'd now do 0x44E06A + 7 = nextInstruction then nextInstruction + 0x24f04f = final VA. But we don't know the section base yet.
-				// Taking our equation nextInstruction + 0x24f04f = final VA, we can rewrite: (sectionBase + offsetNextInstruction) + 0x24f04f = final VA
-				// offsetNextInstruction is the same as our sigPtr + some X which we know based on the signature we wrote.
-				// We therefore finally do moduleDataIpOffset = sigPtr + PCHeaderPtrOffset, sectionBase + moduleDataIpOffset + 0x24f04f = final VA
-				// and that gives us an RVA relative to the sectionBase, which we just add back in whatever calls this function
-				// it's actually simple, just confusing :)
-				moduleDataIpOffset := uint64(sigPtr) + uint64(sigMeta.moduleDataPtrOffsetLoc)
-				return &SignatureMatch{
-					moduleDataPtrOffset + moduleDataIpOffset,
-				}
-			}
+		if sigIdx == uint64(len(signature))-1 {
+			matches = append(matches, callback(uint64(idx-len(signature)+2))...)
+			sigIdx = 0 // reset, scan rest of data for other matches
 		}
 	}
+	return matches
+}
 
-	return nil
+func findModuleInitPCHeader(data []byte, sectionBase uint64, imageBase uint64) []SignatureMatch {
+	var matches []SignatureMatch = make([]SignatureMatch, 0)
+
+	// x64 scan
+	matches = append(matches, findPattern(data, x64sig.signature, func(sigPtr uint64) []SignatureMatch {
+		// this is the pointer offset stored in the instruction
+		// 0x44E06A:       48 8D 0D 4F F0 24 00 lea     rcx, off_69D0C0 (result: 0x24f04f)
+		moduleDataPtrOffset := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(x64sig.moduleDataPtrLoc):][:4]))
+
+		// typically you'd now do 0x44E06A + 7 = nextInstruction then nextInstruction + 0x24f04f = final VA. But we don't know the section base yet.
+		// Taking our equation nextInstruction + 0x24f04f = final VA, we can rewrite: (sectionBase + offsetNextInstruction) + 0x24f04f = final VA
+		// offsetNextInstruction is the same as our sigPtr + some X which we know based on the signature we wrote.
+		// We therefore finally do moduleDataIpOffset = sigPtr + PCHeaderPtrOffset, sectionBase + moduleDataIpOffset + 0x24f04f = final VA
+		// and that gives us an RVA relative to the sectionBase, which we just add back in whatever calls this function
+		// it's actually simple, just confusing :)
+		moduleDataIpOffset := uint64(sigPtr) + uint64(x64sig.moduleDataPtrOffsetLoc)
+		return []SignatureMatch{{
+			moduleDataPtrOffset + moduleDataIpOffset + sectionBase,
+		}}
+	})...)
+
+	// PPC BE scan
+	matches = append(matches, findPattern(data, PPC_BE_sig.signature, func(sigPtr uint64) []SignatureMatch {
+		moduleDataPtrHi := uint64(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrHi):][:2]))
+		moduleDataPtrLo := uint64(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrLo):][:2]))
+
+		moduleDataIpOffset := (moduleDataPtrHi << 16) + moduleDataPtrLo
+		return []SignatureMatch{{
+			moduleDataIpOffset - imageBase,
+		}}
+	})...)
+
+	return matches
 }

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -1,0 +1,82 @@
+
+package objfile
+
+import (
+	"encoding/binary"
+)
+
+type signatureMetaData struct {
+	PCHeaderPtrLoc		int        // offset in signature to the location of the pointer to the PCHeader
+	targetInstIdx		int        // offset in signature to the instruction after the PCHeader pointer
+	signature			[]byte     // signature to search for (0x90 is wildcard)
+}
+
+var peSigs = []signatureMetaData {
+	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
+}
+
+var elfSigs = []signatureMetaData {
+	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
+}
+
+var machoSigs = []signatureMetaData {
+	{21, 25, []byte("\x48\x8D\x05\x90\x90\x90\x90\x90\xE8\x90\x90\x90\x90\x48\x89\x44\x24\x90\x48\x8D\x0D\x90\x90\x90\x90\xEB\x0D")},
+}
+
+
+const (
+	peScanner	    uint32 = 0x1
+	elfScanner 	    uint32 = 0x2
+	machoScanner	uint32 = 0x3
+)
+
+func findModuleInitPCHeader(os uint32, data []byte) []uint64 {
+	var sigs []signatureMetaData
+	switch os {
+	case 1:
+		sigs = peSigs
+	case 2:
+		sigs = elfSigs
+	case 3:
+		sigs = machoSigs
+	}
+
+	for _, sigMeta := range sigs {
+		var sigIdx = 0
+		var isMatch = false
+		var sigPtr = 0
+		for idx := range data {
+			if len(data[idx:]) < len(sigMeta.signature) - sigIdx {
+				break
+			}
+
+			if sigMeta.signature[sigIdx] == 0x90 {
+				// nop instruction is considered "wildcard"
+				sigIdx += 1
+			} else if sigMeta.signature[sigIdx] == data[idx] {
+				// Byte in signature is equal to position in data
+				sigIdx += 1
+			} else {
+				// No match
+				isMatch = false
+				sigIdx = 0
+				continue
+			}
+
+			// store start index for signature attempt when it is a good signature 
+			if !isMatch {
+				sigPtr = idx
+				isMatch = true
+			}
+
+			if sigIdx == len(sigMeta.signature)-1 {
+				// found a match, return on first match
+                moduleData := binary.LittleEndian.Uint32(data[sigPtr+sigMeta.PCHeaderPtrLoc:][:4])
+				return []uint64{uint64(moduleData), uint64(sigPtr)+uint64(sigMeta.targetInstIdx)}
+			}
+		}
+	}
+
+	return []uint64{}
+
+}

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -2,151 +2,138 @@ package objfile
 
 import (
 	"encoding/binary"
+
+	"github.com/hillu/go-yara/v4"
 )
 
 type signatureModuleDataInitx64 struct {
-	moduleDataPtrLoc       uint8  // offset in signature to the location of the pointer to the PCHeader
-	moduleDataPtrOffsetLoc uint8  // Ptr is a relative ptr, we need to include the instruction length + next instruction IP to resolve final VA
-	signature              []byte // signature to search for (0x90 is wildcard)
+	moduleDataPtrLoc       uint8 // offset in signature to the location of the pointer to the PCHeader
+	moduleDataPtrOffsetLoc uint8 // Ptr is a relative ptr, we need to include the instruction length + next instruction IP to resolve final VA
+	signature              string
+	namespace              string
 }
 
 type signatureModuleDataInitx86 struct {
-	moduleDataPtrLoc    uint8  // offset in signature to the location of the pointer to the PCHeader (ptr is absolute addr)
-	moduleDataSignature []byte // signature to search for (0x90 is wildcard)
-
-	loopMaxDistanceFromModuleData uint16 // max distance between moduleDataSignature match and loopSignature
-	loopSignature                 []byte
+	moduleDataPtrLoc uint8 // offset in signature to the location of the pointer to the PCHeader (ptr is absolute addr)
+	signature        string
+	namespace        string
 }
 
 type signatureModuleDataInitPPC struct {
 	moduleDataPtrHi uint8
 	moduleDataPtrLo uint8
-	signature       []byte // signature to search for (0x90 is wildcard)
+	signature       string
+	namespace       string
 }
 
 type SignatureMatch struct {
 	moduleDataVA uint64
 }
 
-// .text:000000000044D80A 48 8D 0D 8F DA 26 00                    lea     rcx, runtime_firstmoduledata
-// .text:000000000044D811 EB 0D                                   jmp     short loc_44D820
-// .text:000000000044D813 48 8B 89 30 02 00 00                    mov     rcx, [rcx+230h]
-// .text:000000000044D81A 66 0F 1F 44 00 00                       nop     word ptr [rax+rax+00h]    <- always seems to be present
-var x64sig = signatureModuleDataInitx64{3, 7, []byte("48 8D 0? ?? ?? ?? ?? EB ?? 48 8? 8? ?? 02 00 00 66 0F 1F 44 00 00")}
+// 0x000000000044D80A: 48 8D 0D 8F DA 26 00                    lea     rcx, runtime_firstmoduledata
+// 0x000000000044D811: EB 0D                                   jmp     short loc_44D820
+// 0x000000000044D813: 48 8B 89 30 02 00 00                    mov     rcx, [rcx+230h]
+// 0x000000000044D81A: 66 0F 1F 44 00 00                       nop     word ptr [rax+rax+00h]    <- always seems to be present
+var x64sig = signatureModuleDataInitx64{3, 7, `rule x64firstmoduledata
+{
+    strings:
+        $sig = { 48 8D 0? ?? ?? ?? ?? EB ?? 48 8? 8? ?? 02 00 00 66 0F 1F 44 00 00 }
+    condition:
+        $sig
+}`, "x64"}
 
-// .text:00438A94 8D 05 60 49 6A 00                       lea     eax, off_6A4960
-// .text:00438A9A EB 1A                                   jmp     short loc_438AB6
+// 0x00438A94: 8D 05 60 49 6A 00                       lea     eax, off_6A4960
+// 0x00438A9A: EB 1A                                   jmp     short loc_438AB6
 // ...gap...
-// .text:00438AAC 8B 80 18 01 00 00                       mov     eax, [eax+118h]
-// .text:00438AB2 8B 54 24 20                             mov     edx, [esp+2Ch+var_C]
-// .text:00438AB6
-// .text:00438AB6                         loc_438AB6:                             ; CODE XREF: sub_438A60+3A↑j
-// .text:00438AB6 85 C0                                   test    eax, eax
-// .text:00438AB8 75 E2                                   jnz     short loc_438A9C
-var x86sig = signatureModuleDataInitx86{2, []byte("8D ?? ?? ?? ?? ?? EB ??"), 50, []byte("8B ?? ?? 01 00 00 8B ?? ?? ?? 85 ?? 75 ??")}
+// 0x00438AAC: 8B 80 18 01 00 00                       mov     eax, [eax+118h]
+// 0x00438AB2: 8B 54 24 20                             mov     edx, [esp+2Ch+var_C]
+// 0x00438AB6:
+// 0x00438AB6:                         loc_438AB6:                             ; CODE XREF: sub_438A60+3A↑j
+// 0x00438AB6: 85 C0                                   test    eax, eax
+// 0x00438AB8: 75 E2                                   jnz     short loc_438A9C
+var x86sig = signatureModuleDataInitx86{2, `rule x86firstmoduledata
+{
+    strings:
+        $sig = { 8D ?? ?? ?? ?? ?? EB ?? [8-50] 8B ?? ?? 01 00 00 8B ?? ?? ?? 85 ?? 75 ??}
+    condition:
+        $sig
+}`, "x86"}
 
 // 0x0000000000061a74:  3C 80 00 2C    lis  r4, 0x2c       // moduledata
-// 0x0000000000061a78:  38 84 80 00    addi r4, r4, 0x8000  // moduledata ((0x2c << 16) + 0x8000)
+// 0x0000000000061a78:  38 84 80 00    addi r4, r4, 0x8000  // moduledata ((0x2c << 16) - 0x8000)
 // 0x0000000000061a7c:  48 00 00 08    b    0x61a84
 // 0x0000000000061a80:  E8 84 02 30    ld   r4, 0x230(r4)
 // 0x0000000000061a84:  7C 24 00 00    cmpd r4, r0
 // 0x0000000000061a88:  41 82 01 A8    beq  0x61c30
-var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("3? 80 00 ?? 3? ?? ?? ?? 48 ?? ?? ?? E? ?? 02 ?? 7C ?? ?? ?? 41 82 ?? ??")}
+var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, `rule PPC_BEfirstmoduledata
+{
+    strings:
+        $sig = { 3? 80 00 ?? 3? ?? ?? ?? 48 ?? ?? ?? E? ?? 02 ?? 7C ?? ?? ?? 41 82 ?? ??}
+    condition:
+        $sig
+}`, "PPC_BE"}
 
-func getPatternSize(signature []byte) int {
-	// c = 2 * b + (b - 1) . 2 chars per byte + b - 1 spaces between
-	return (len(signature) + 1) / 3
-}
-
-func getBits(x byte) byte {
-	if x >= '0' && x <= '9' {
-		return x - '0'
-	} else {
-		return (x & 0xDF) - 'A' + 0xa
-	}
-}
-
-// Pattern must have a space per byte, use ? as wildcard for nibbles, and be uppercase ascii text without the 0x or /x prefix
-func findPattern(data []byte, signature []byte, callback func(uint64) []SignatureMatch) []SignatureMatch {
-	var matches []SignatureMatch = make([]SignatureMatch, 0)
-	patternSize := getPatternSize(signature)
-	for i := range data {
-		sigIdx := 0
-		for sigIdx < patternSize && i+sigIdx < len(data) {
-			sigPatIdx := sigIdx * 3
-			sigHi := getBits(signature[sigPatIdx:][0]) << 4
-			sigLo := getBits(signature[sigPatIdx:][1])
-			datByt := data[i+sigIdx:][0]
-
-			// check for ex: A?
-			if signature[sigPatIdx+1] == '?' {
-				sigLo = datByt & 0xF
-			}
-
-			if signature[sigPatIdx] == '?' {
-				sigHi = datByt & 0xF0
-			}
-
-			if datByt != (sigHi | sigLo) {
-				break
-			}
-
-			sigIdx += 1
-		}
-
-		if sigIdx >= patternSize {
-			matches = append(matches, callback(uint64(i))...)
-		}
-	}
-	return matches
-}
+// 0x000000000005C1E8 41 14 00 F0        ADRP            X1, #unk_2E7000    // 0xF0001441 -> 0b1 11 10000 0000000000010100010 00001 -> op=1, immlo=0b11, immhi=0b0000000000010100010
+// ........................................................................ // X1 = ((0b0000000000010100010 11 << 12) + 0x5C1E8) = 0b1011100111000111101000 = 0b1011100111000111101000 & 0xFFFFFFFFFFFFF000 = 0x2E7000
+// 0x000000000005C1EC 21 80 3D 91        ADD             X1, X1, #firstmoduleData@PAGEOFF // 0x913d8021 -> 0b100 100010 0 111101100000 00001 00001 -> sh = 0, imm12 = 0b111101100000, Rn = 00001, Rb = 00001
+// ....................................................................... // X1 = 0x2E7000 + 0b111101100000 (0xF60) = 0x2E7F60
+// 0x000000000005C1F0 02 00 00 14        B               loc_5C1F8     0x14 00 00 02
+// 0x000000000005C1F4 21 18 41 F9        LDR             X1, [X1,#0x230]
+// 0x000000000005C1F8 21 0D 00 B4        CBZ             X1, loc_5C39C   0xb4000d21
+// var ARM64_sig = ?? ?? ?? (90 | b0 | f0 | d0) ?? ?? ?? 91 ?? ?? ?? (14 | 17) ?? ?? 41 F9 ?? ?? ?? B4
 
 func findModuleInitPCHeader(data []byte, sectionBase uint64) []SignatureMatch {
 	var matches []SignatureMatch = make([]SignatureMatch, 0)
 
-	// x64 scan
-	matches = append(matches, findPattern(data, x64sig.signature, func(sigPtr uint64) []SignatureMatch {
-		// this is the pointer offset stored in the instruction
-		// 0x44E06A:       48 8D 0D 4F F0 24 00 lea     rcx, off_69D0C0 (result: 0x24f04f)
-		moduleDataPtrOffset := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(x64sig.moduleDataPtrLoc):][:4]))
+	c, _ := yara.NewCompiler()
+	c.AddString(x64sig.signature, x64sig.namespace)
+	c.AddString(x86sig.signature, x86sig.namespace)
+	c.AddString(PPC_BE_sig.signature, PPC_BE_sig.namespace)
+	rules, err := c.GetRules()
+	if err != nil {
+		return matches
+	}
 
-		// typically you'd now do 0x44E06A + 7 = nextInstruction then nextInstruction + 0x24f04f = final VA. But we don't know the section base yet.
-		// Taking our equation nextInstruction + 0x24f04f = final VA, we can rewrite: (sectionBase + offsetNextInstruction) + 0x24f04f = final VA
-		// offsetNextInstruction is the same as our sigPtr + some X which we know based on the signature we wrote.
-		// We therefore finally do moduleDataIpOffset = sigPtr + PCHeaderPtrOffset, sectionBase + moduleDataIpOffset + 0x24f04f = final VA
-		// and that gives us an RVA relative to the sectionBase, which we just add back in whatever calls this function
-		// it's actually simple, just confusing :)
-		moduleDataIpOffset := uint64(sigPtr) + uint64(x64sig.moduleDataPtrOffsetLoc)
-		return []SignatureMatch{{
-			moduleDataPtrOffset + moduleDataIpOffset + sectionBase,
-		}}
-	})...)
+	var yara_matches yara.MatchRules
+	scanner, err := yara.NewScanner(rules)
+	if err != nil {
+		return matches
+	}
+	scanner.SetCallback(&yara_matches)
 
-	// x86 scan
-	matches = append(matches, findPattern(data, x86sig.moduleDataSignature, func(sigPtr uint64) []SignatureMatch {
-		return findPattern(data[sigPtr:], x86sig.loopSignature, func(sigPtr2 uint64) []SignatureMatch {
-			if sigPtr2 < uint64(x86sig.loopMaxDistanceFromModuleData) {
+	scanner.ScanMem(data)
+	for _, match := range yara_matches {
+		for _, match_str := range match.Strings {
+			sigPtr := match_str.Offset
+			if match.Namespace == x64sig.namespace {
+				// this is the pointer offset stored in the instruction
+				// 0x44E06A:       48 8D 0D 4F F0 24 00 lea     rcx, off_69D0C0 (result: 0x24f04f)
+				moduleDataPtrOffset := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(x64sig.moduleDataPtrLoc):][:4]))
+
+				// the ptr we get is position dependant, add the sigPtr + sectionBase to get current IP, then offset to next instruction
+				// as relative ptrs are encoded by the NEXT instruction va, not the current one
+				moduleDataIpOffset := sigPtr + sectionBase + uint64(x64sig.moduleDataPtrOffsetLoc)
+				matches = append(matches, SignatureMatch{
+					moduleDataPtrOffset + moduleDataIpOffset,
+				})
+			} else if match.Namespace == x86sig.namespace {
 				moduleDataPtr := uint64(binary.LittleEndian.Uint32(data[sigPtr+uint64(x86sig.moduleDataPtrLoc):][:4]))
-				return []SignatureMatch{{
+				matches = append(matches, SignatureMatch{
 					moduleDataPtr,
-				}}
+				})
+			} else if match.Namespace == PPC_BE_sig.namespace {
+				moduleDataPtrHi := int64(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrHi):][:2]))
+
+				// addi takes a signed immediate
+				moduleDataPtrLo := int64(int16(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrLo):][:2])))
+
+				moduleDataIpOffset := uint64((moduleDataPtrHi << 16) + moduleDataPtrLo)
+				matches = append(matches, SignatureMatch{
+					moduleDataIpOffset,
+				})
 			}
-			return make([]SignatureMatch, 0)
-		})
-	})...)
-
-	// PPC BE scan
-	matches = append(matches, findPattern(data, PPC_BE_sig.signature, func(sigPtr uint64) []SignatureMatch {
-		moduleDataPtrHi := int64(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrHi):][:2]))
-
-		// addi takes a signed immediate
-		moduleDataPtrLo := int64(int16(binary.BigEndian.Uint16(data[sigPtr+uint64(PPC_BE_sig.moduleDataPtrLo):][:2])))
-
-		moduleDataIpOffset := uint64((moduleDataPtrHi << 16) + moduleDataPtrLo)
-		return []SignatureMatch{{
-			moduleDataIpOffset,
-		}}
-	})...)
+		}
+	}
 
 	return matches
 }

--- a/objfile/scanner.go
+++ b/objfile/scanner.go
@@ -43,7 +43,7 @@ var x64sig = signatureModuleDataInitx64{3, 7, []byte("48 8D 0? ?? ?? ?? ?? EB ??
 // .text:00438AB6                         loc_438AB6:                             ; CODE XREF: sub_438A60+3A↑j
 // .text:00438AB6 85 C0                                   test    eax, eax
 // .text:00438AB8 75 E2                                   jnz     short loc_438A9C
-var x86sig = signatureModuleDataInitx86{2, []byte("8D ?? ?? ?? ?? ?? EB 1A"), 50, []byte("8B ?? ?? ?? ?? ?? 8B ?? 24 20 85 ?? 75 E2")}
+var x86sig = signatureModuleDataInitx86{2, []byte("8D ?? ?? ?? ?? ?? EB ??"), 50, []byte("8B ?? ?? 01 00 00 8B ?? ?? ?? 85 ?? 75 ??")}
 
 // 0x0000000000061a74:  3C 80 00 2C    lis  r4, 0x2c       // moduledata
 // 0x0000000000061a78:  38 84 80 00    addi r4, r4, 0x8000  // moduledata ((0x2c << 16) + 0x8000)
@@ -51,7 +51,7 @@ var x86sig = signatureModuleDataInitx86{2, []byte("8D ?? ?? ?? ?? ?? EB 1A"), 50
 // 0x0000000000061a80:  E8 84 02 30    ld   r4, 0x230(r4)
 // 0x0000000000061a84:  7C 24 00 00    cmpd r4, r0
 // 0x0000000000061a88:  41 82 01 A8    beq  0x61c30
-var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("3? 80 00 2C 3? ?? 80 00 48 ?? ?? 08 E? ?? 02 30 7C ?? 00 00 41 82 ?? ??")}
+var PPC_BE_sig = signatureModuleDataInitPPC{2, 6, []byte("3? 80 00 ?? 3? ?? ?? ?? 48 ?? ?? ?? E? ?? 02 ?? 7C ?? ?? ?? 41 82 ?? ??")}
 
 func getPatternSize(signature []byte) int {
 	// c = 2 * b + (b - 1) . 2 chars per byte + b - 1 spaces between


### PR DESCRIPTION
Hello!

I've run into a recurring issue with packed/obfuscated samples, where the pclntab magic will be modified. This breaks GoReSym, particularly when trying to validate the table by loading it. This PR contains a fix that I've been using as a python script, but consolidating would be nice.

The fix does a couple things to accomplish a 'best guess' scan for the pclntab:
- Removed short-circuit when scanner thinks it finds valid pclntab via symbol, continue to do bytescans anyways
- Added scan for table by searching for first entry (internal/cpu.Initialize)
- For each signature in pclntab signatures, add a candidate with the valid signature magic bytes (encompass potential Go versions)

This had no major noticeable performance hits for valid Go binaries, although it did take a bit longer when trying to repair the packed/obfuscated files I've run across.

The reason for removing the short circuit is because even if the pclntab symbol may still exist, it points to the mangled pclntab which cannot be loaded by GoReSym. Removing this and just letting it go through the repair scan didn't cause any issues in my testing and still provided useful results on mangled binaries.

I am not so familiar with the Go runtime, nor the GoReSym codebase, so if you have a more optimal way to implement this I am all ears.

Please let me know if you have any comments, questions, or concerns.
Thanks!