### PR TITLE
pe: cache DataAfterSection for performance

### DIFF
--- a/objfile/pe.go
+++ b/objfile/pe.go
@@ -20,7 +20,8 @@ import (
 )
 
 type peFile struct {
-	pe *pe.File
+	pe                    *pe.File
+	dataAfterSectionCache map[*pe.Section][]byte
 }
 
 func openPE(r io.ReaderAt) (rawFile, error) {
@@ -28,7 +29,7 @@ func openPE(r io.ReaderAt) (rawFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &peFile{f}, nil
+	return &peFile{f, make(map[*pe.Section][]byte)}, nil
 }
 
 func (f *peFile) read_memory(VA uint64, size uint64) (data []byte, err error) {
@@ -127,6 +128,15 @@ func (f *peFile) symbols() ([]Sym, error) {
 	return syms, nil
 }
 
+func (f *peFile) dataAfterSection(sec *pe.Section) []byte {
+	if data, ok := f.dataAfterSectionCache[sec]; ok {
+		return data
+	}
+	data, _ := sec.Data()
+	f.dataAfterSectionCache[sec] = data
+	return data
+}
+
 func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	var imageBase uint64
 	switch oh := f.pe.OptionalHeader.(type) {
@@ -176,7 +186,7 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	// 2) if not found, byte scan for it
 	for _, sec := range f.pe.Sections {
 		// malware can split the pclntab across multiple sections, re-merge
-		data := f.pe.DataAfterSection(sec)
+		data := f.dataAfterSection(sec)
 
 		if !foundpcln {
 			matches := findAllOccurrences(data, pclntab_sigs)
@@ -288,7 +298,7 @@ func (f *peFile) pcln_scan() (candidates []PclntabCandidate, err error) {
 	if len(stompedmagic_candidates) != 0 {
 		for _, sec := range f.pe.Sections {
 			// malware can split the pclntab across multiple sections, re-merge
-			data := f.pe.DataAfterSection(sec)
+			data := f.dataAfterSection(sec)
 			for _, stompedMagicCandidate := range stompedmagic_candidates {
 				pclntab_va_candidate := stompedMagicCandidate.PclntabVa
 
@@ -391,7 +401,7 @@ func (f *peFile) moduledata_scan(pclntabVA uint64, is64bit bool, littleendian bo
 scan:
 	for _, sec := range f.pe.Sections {
 		// malware can split the pclntab across multiple sections, re-merge
-		data := f.pe.DataAfterSection(sec)
+		data := f.dataAfterSection(sec)
 
 		if !foundmodule {
 			// fall back to scanning for structure using address of pclntab, which is first value in struc


### PR DESCRIPTION
cache the results of `DataAfterSection` since they're expensive to compute (lots of data copied around). instead, trade this for higher memory usage (expected to be `O(number of (sections * file size) / 2)`).

before:

```
❯ time ./GoReSym 11d7cb5750c44c40e767c7c4fa0f388ed64f636cf6b97ceee7bf9ae77683a3c0 > /dev/null
2023/07/21 13:18:58 profile: cpu profiling enabled, cpu.pprof
GoReSym: profile: cpu profiling disabled, cpu.pprof

________________________________________________________
Executed in   15.20 secs    fish           external
   usr time   15.01 secs  151.00 micros   15.01 secs
   sys time    0.87 secs  136.00 micros    0.87 secs

❯ pprof -cum -top cpu.pprof
File: GoReSym
Type: cpu
Time: Jul 21, 2023 at 1:18pm (CEST)
Duration: 15.19s, Total samples = 15.42s (101.50%)
Showing nodes accounting for 14.99s, 97.21% of 15.42s total
Dropped 88 nodes (cum <= 0.08s)
      flat  flat%   sum%        cum   cum%
         0     0%     0%     14.67s 95.14%  main.main
         0     0%     0%     14.67s 95.14%  runtime.main
     0.01s 0.065% 0.065%     14.40s 93.39%  main.main_impl
         0     0% 0.065%     12.78s 82.88%  github.com/mandiant/GoReSym/objfile.(*Entry).PCLineTable
         0     0% 0.065%     12.78s 82.88%  github.com/mandiant/GoReSym/objfile.(*File).PCLineTable (inline)
         0     0% 0.065%     12.65s 82.04%  github.com/mandiant/GoReSym/objfile.(*peFile).pcln
     0.29s  1.88%  1.95%     12.65s 82.04%  github.com/mandiant/GoReSym/objfile.(*peFile).pcln_scan
     4.57s 29.64% 31.58%     12.14s 78.73%  github.com/mandiant/GoReSym/objfile.findAllOccurrences (inline)
     1.03s  6.68% 38.26%      7.57s 49.09%  bytes.Equal (inline)
     5.48s 35.54% 73.80%      5.48s 35.54%  memeqbody
         0     0% 73.80%      1.47s  9.53%  github.com/mandiant/GoReSym/objfile.(*Entry).ModuleDataTable
         0     0% 73.80%      1.47s  9.53%  github.com/mandiant/GoReSym/objfile.(*File).ModuleDataTable
         0     0% 73.80%      1.47s  9.53%  github.com/mandiant/GoReSym/objfile.(*peFile).moduledata_scan
         0     0% 73.80%      1.39s  9.01%  github.com/mandiant/GoReSym/debug/pe.(*File).DataAfterSection
     1.06s  6.87% 80.67%      1.06s  6.87%  runtime.memequal
     0.79s  5.12% 85.80%      0.79s  5.12%  runtime.memmove
         0     0% 85.80%      0.79s  5.12%  runtime.systemstack
         0     0% 85.80%      0.72s  4.67%  runtime.gcBgMarkWorker
         0     0% 85.80%      0.72s  4.67%  runtime.gcBgMarkWorker.func2
         0     0% 85.80%      0.72s  4.67%  runtime.gcDrain
         0     0% 85.80%      0.56s  3.63%  github.com/mandiant/GoReSym/debug/pe.(*Section).Data
         0     0% 85.80%      0.53s  3.44%  runtime.growslice   
```

after:

```
❯ time ./GoReSym 11d7cb5750c44c40e767c7c4fa0f388ed64f636cf6b97ceee7bf9ae77683a3c0 > /dev/null
2023/07/21 14:56:40 profile: cpu profiling enabled, cpu.pprof
GoReSym: profile: cpu profiling disabled, cpu.pprof

________________________________________________________
Executed in    7.34 secs    fish           external
   usr time    7.15 secs  151.00 micros    7.15 secs
   sys time    0.10 secs  141.00 micros    0.10 secs


❯ pprof -cum -top cpu.pprof
File: GoReSym
Type: cpu
Time: Jul 21, 2023 at 2:56pm (CEST)
Duration: 7.33s, Total samples = 7.15s (97.58%)
Showing nodes accounting for 6.99s, 97.76% of 7.15s total
Dropped 66 nodes (cum <= 0.04s)
      flat  flat%   sum%        cum   cum%
         0     0%     0%      7.11s 99.44%  main.main
         0     0%     0%      7.11s 99.44%  runtime.main
     0.01s  0.14%  0.14%      6.88s 96.22%  main.main_impl
         0     0%  0.14%      6.72s 93.99%  github.com/mandiant/GoReSym/objfile.(*Entry).PCLineTable
         0     0%  0.14%      6.72s 93.99%  github.com/mandiant/GoReSym/objfile.(*File).PCLineTable (inline)
         0     0%  0.14%      6.62s 92.59%  github.com/mandiant/GoReSym/objfile.(*peFile).pcln
     0.04s  0.56%   0.7%      6.62s 92.59%  github.com/mandiant/GoReSym/objfile.(*peFile).pcln_scan
     2.52s 35.24% 35.94%      6.55s 91.61%  github.com/mandiant/GoReSym/objfile.findAllOccurrences (inline)
     0.47s  6.57% 42.52%      4.03s 56.36%  bytes.Equal (inline)
     3.11s 43.50% 86.01%      3.11s 43.50%  memeqbody

```