### PR TITLE
parse field tag and interface method name

### DIFF
--- a/objfile/objfile.go
+++ b/objfile/objfile.go
@@ -1479,6 +1479,7 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 				parsedTypesIn, _ = e.ParseType_impl(runtimeVersion, moduleData, typeAddr, is64bit, littleendian, parsedTypesIn)
 				methodfunc, found := parsedTypesIn.Get(typeAddr)
 				if found {
+					// TODO: parse method name
 					interfaceDef += "\nmethod" + strconv.Itoa(i) + " " + methodfunc.(Type).Str
 					cinterfaceDef += methodfunc.(Type).CStr + "method" + strconv.Itoa(i) + ";\n"
 				}
@@ -1566,11 +1567,16 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 
 				typeAddr := moduleData.Types + uint64(method.Typ)
 				parsedTypesIn, _ = e.ParseType_impl(runtimeVersion, moduleData, typeAddr, is64bit, littleendian, parsedTypesIn)
+				name_ptr := moduleData.Types + uint64(method.Name)
+				name, _, err := e.readRTypeName(runtimeVersion, 0, name_ptr, is64bit, littleendian)
+				if err != nil {
+					name = "method" + strconv.Itoa(i)
+				}
 
 				methodfunc, found := parsedTypesIn.Get(typeAddr)
 				if found {
-					interfaceDef += "\nmethod" + strconv.Itoa(i) + " " + methodfunc.(Type).Str
-					cinterfaceDef += methodfunc.(Type).CStr + " method" + strconv.Itoa(i) + ";\n"
+					interfaceDef += name + " " + methodfunc.(Type).Str + "\n"
+					cinterfaceDef += methodfunc.(Type).CStr + " " + name + ";\n"
 				}
 			}
 			interfaceDef += "\n}"

--- a/objfile/objfile.go
+++ b/objfile/objfile.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/mandiant/GoReSym/objabi"
 	"io"
 	"os"
 	"sort"
@@ -1575,7 +1576,7 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 
 				methodfunc, found := parsedTypesIn.Get(typeAddr)
 				if found {
-					interfaceDef += name + " " + methodfunc.(Type).Str + "\n"
+					interfaceDef += name + strings.TrimPrefix(methodfunc.(Type).Str, "func") + "\n"
 					cinterfaceDef += methodfunc.(Type).CStr + " " + name + ";\n"
 				}
 			}
@@ -1641,10 +1642,16 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 					typeNameAddr := decodePtrSizeBytes(data[0:ptrSize], is64bit, littleendian)
 					typeName, tag, err := e.readRTypeName(runtimeVersion, 0, typeNameAddr, is64bit, littleendian)
 					if err == nil {
-						if tag != "" {
-							structDef += fmt.Sprintf("\n    %-10s %s `%s`", typeName, field.(Type).Str, tag)
+						var fieldStr string
+						if field.(Type).kindEnum == objabi.KindStruct {
+							fieldStr = strings.TrimPrefix(field.(Type).Reconstructed, "type ")
 						} else {
-							structDef += fmt.Sprintf("\n    %-10s %s", typeName, field.(Type).Str)
+							fieldStr = field.(Type).Str
+						}
+						if tag != "" {
+							structDef += fmt.Sprintf("\n    %-10s %s `%s`", typeName, fieldStr, tag)
+						} else {
+							structDef += fmt.Sprintf("\n    %-10s %s", typeName, fieldStr)
 						}
 						cstructDef += fmt.Sprintf("    %-10s %s;\n", field.(Type).CStr, replace_cpp_keywords(typeName))
 					}
@@ -1738,10 +1745,16 @@ func (e *Entry) ParseType_impl(runtimeVersion string, moduleData *ModuleData, ty
 					typeNameAddr := decodePtrSizeBytes(data[0:ptrSize], is64bit, littleendian)
 					typeName, tag, err := e.readRTypeName(runtimeVersion, 0, typeNameAddr, is64bit, littleendian)
 					if err == nil {
-						if tag != "" {
-							structDef += fmt.Sprintf("\n    %-10s %s `%s`", typeName, field.(Type).Str, tag)
+						var fieldStr string
+						if field.(Type).kindEnum == objabi.KindStruct {
+							fieldStr = strings.TrimPrefix(field.(Type).Reconstructed, "type ")
 						} else {
-							structDef += fmt.Sprintf("\n    %-10s %s", typeName, field.(Type).Str)
+							fieldStr = field.(Type).Str
+						}
+						if tag != "" {
+							structDef += fmt.Sprintf("\n    %-10s %s `%s`", typeName, fieldStr, tag)
+						} else {
+							structDef += fmt.Sprintf("\n    %-10s %s", typeName, fieldStr)
 						}
 						cstructDef += fmt.Sprintf("    %-10s %s;\n", field.(Type).CStr, replace_cpp_keywords(typeName))
 					}


### PR DESCRIPTION
fix https://github.com/mandiant/GoReSym/issues/37

the sample binary source code is

```go
package main

import "fmt"

type interface1 interface {
	Interface1Method()
	interface1Method1(string, int) (string, error)
}

type ExampleStruct struct {
	StructField string `json:"StructFieldTag"`
}

type ExampleStruct1 struct {
	Data struct {
		StructField1 string `json:"StructFieldTag1"`
	} `json:"DataTag"`
}

func (e *ExampleStruct1) Interface1Method() {
	fmt.Println("Interface1Method")
}

func (e *ExampleStruct1) interface1Method1(string, int) (string, error) {
	fmt.Println("interface1Method1")
	return "", nil
}

func main() {
	fmt.Println(ExampleStruct{}, ExampleStruct1{})
	var i interface1
	i = &ExampleStruct1{}
	i.Interface1Method()
}
```

diff of this branch vs master

![image](https://github.com/mandiant/GoReSym/assets/4939404/e1d0d0f3-d65e-4a18-8bea-c57049c899be)

![image](https://github.com/mandiant/GoReSym/assets/4939404/70ef1ffe-38b7-411c-9fd4-26ec2e8e1c7a)

**Note**

-`Reconstructed` field is not valid golang code in many cases, so i add some hack to make it to valid format in common cases.
