### PR TITLE
Fix: Redundant read ELF sections cause memory exhaustion

### DIFF
--- a/debug/elf/file.go
+++ b/debug/elf/file.go
@@ -701,14 +701,11 @@ func (f *File) DataAfterSection(target *Section) []byte {
 		}
 
 		if found {
-			raw, err := s.Data()
+			raw, _ := s.Data()
 			if raw != nil {
 				data = append(data, raw[:]...)
 			}
-
-			if err != nil {
-				break
-			}
+			break
 		}
 	}
 


### PR DESCRIPTION
The function `pcln_scan()` does not stop reading section data upon encountering it, potentially leading to excessive memory consumption. I conducted a test using an ELF binary of approximately 100 MB, which was terminated by the OOM killer. This PR aims to address the issue