### PR TITLE
Optionally skip printing the function sections

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ type ExtractMetadata struct {
 	StdFunctions  []FuncMetadata
 }
 
-func main_impl_tmpfile(fileBytes []byte, printStdPkgs bool, printFilePaths bool, printTypes bool, manualTypeAddress int, versionOverride string, noPrintFunctions bool) (metadata ExtractMetadata, err error) {
+func main_impl_tmpfile(fileBytes []byte, printStdPkgs bool, printFilePaths bool, printTypes bool, noPrintFunctions bool, manualTypeAddress int, versionOverride string) (metadata ExtractMetadata, err error) {
 	tmpFile, err := os.CreateTemp(os.TempDir(), "goresym_tmp-")
 	if err != nil {
 		return ExtractMetadata{}, fmt.Errorf("failed to create temporary file: %s", err)
@@ -81,10 +81,10 @@ func main_impl_tmpfile(fileBytes []byte, printStdPkgs bool, printFilePaths bool,
 		return ExtractMetadata{}, fmt.Errorf("failed to close temporary file: %s", err)
 	}
 
-	return main_impl(tmpFile.Name(), printStdPkgs, printFilePaths, printTypes, manualTypeAddress, versionOverride, noPrintFunctions)
+	return main_impl(tmpFile.Name(), printStdPkgs, printFilePaths, printTypes, noPrintFunctions, manualTypeAddress, versionOverride)
 }
 
-func main_impl(fileName string, printStdPkgs bool, printFilePaths bool, printTypes bool, manualTypeAddress int, versionOverride string, noPrintFunctions bool) (metadata ExtractMetadata, err error) {
+func main_impl(fileName string, printStdPkgs bool, printFilePaths bool, printTypes bool, noPrintFunctions bool, manualTypeAddress int, versionOverride string) (metadata ExtractMetadata, err error) {
 	extractMetadata := ExtractMetadata{}
 
 	file, err := objfile.Open(fileName)
@@ -424,10 +424,10 @@ func main() {
 	printStdPkgs := flag.Bool("d", false, "Print Default Packages")
 	printFilePaths := flag.Bool("p", false, "Print File Paths")
 	printTypes := flag.Bool("t", false, "Print types automatically, enumerate typelinks and itablinks")
+	noPrintFunctions := flag.Bool("nofuncs", false, "Do not print user and standard function sections")
 	typeAddress := flag.Int("m", 0, "Manually parse the RTYPE at the provided virtual address, disables automated enumeration of moduledata typelinks itablinks")
 	versionOverride := flag.String("v", "", "Override the automated version detection, ex: 1.17. If this is wrong, parsing may fail or produce nonsense")
 	humanView := flag.Bool("human", false, "Human view, print information flat rather than json, some information is omitted for clarity")
-	noPrintFunctions := flag.Bool("no-functions", false, "Do not print user and standard function sections")
 	flag.Parse()
 
 	if *about {
@@ -445,7 +445,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	metadata, err := main_impl(flag.Arg(0), *printStdPkgs, *printFilePaths, *printTypes, *typeAddress, *versionOverride, *noPrintFunctions)
+	metadata, err := main_impl(flag.Arg(0), *printStdPkgs, *printFilePaths, *printTypes, *noPrintFunctions, *typeAddress, *versionOverride)
 	if err != nil {
 		fmt.Println(TextToJson("error", fmt.Sprintf("Failed to parse file: %s", err)))
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestAllVersions(t *testing.T) {
 			}
 
 			t.Run(versionPath, func(t *testing.T) {
-				data, err := main_impl(filePath, true, true, true, 0, "")
+				data, err := main_impl(filePath, true, true, true, 0, "", true)
 				if err != nil {
 					t.Errorf("Go %s failed on %s: %s", v, file, err)
 				}
@@ -119,7 +119,7 @@ func testSymbolRecovery(t *testing.T, workingDirectory string, binaryName string
 		return
 	}
 
-	data, err := main_impl(filePath, true, true, true, 0, "")
+	data, err := main_impl(filePath, true, true, true, 0, "", true)
 	if err != nil {
 		t.Errorf("GoReSym failed: %s", err)
 	}
@@ -214,7 +214,7 @@ func TestWeirdBins(t *testing.T) {
 			return
 		}
 
-		_, err := main_impl(filePath, true, true, true, 0, "")
+		_, err := main_impl(filePath, true, true, true, 0, "", true)
 		if err == nil {
 			t.Errorf("GoReSym found pclntab in a non-go binary, this is not possible.")
 		}
@@ -228,7 +228,7 @@ func TestWeirdBins(t *testing.T) {
 			return
 		}
 
-		_, err := main_impl(filePath, true, true, true, 0, "")
+		_, err := main_impl(filePath, true, true, true, 0, "", true)
 		if err == nil {
 			t.Errorf("GoReSym found pclntab in a non-go binary, this is not possible.")
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestAllVersions(t *testing.T) {
 			}
 
 			t.Run(versionPath, func(t *testing.T) {
-				data, err := main_impl(filePath, true, true, true, 0, "", true)
+				data, err := main_impl(filePath, true, true, true, true, 0, "")
 				if err != nil {
 					t.Errorf("Go %s failed on %s: %s", v, file, err)
 				}
@@ -119,7 +119,7 @@ func testSymbolRecovery(t *testing.T, workingDirectory string, binaryName string
 		return
 	}
 
-	data, err := main_impl(filePath, true, true, true, 0, "", true)
+	data, err := main_impl(filePath, true, true, true, true, 0, "")
 	if err != nil {
 		t.Errorf("GoReSym failed: %s", err)
 	}
@@ -214,7 +214,7 @@ func TestWeirdBins(t *testing.T) {
 			return
 		}
 
-		_, err := main_impl(filePath, true, true, true, 0, "", true)
+		_, err := main_impl(filePath, true, true, true, true, 0, "")
 		if err == nil {
 			t.Errorf("GoReSym found pclntab in a non-go binary, this is not possible.")
 		}
@@ -228,7 +228,7 @@ func TestWeirdBins(t *testing.T) {
 			return
 		}
 
-		_, err := main_impl(filePath, true, true, true, 0, "", true)
+		_, err := main_impl(filePath, true, true, true, true, 0, "")
 		if err == nil {
 			t.Errorf("GoReSym found pclntab in a non-go binary, this is not possible.")
 		}


### PR DESCRIPTION
Add a new `-no-functions` command line flag to skip printing the `UserFunctions` and `StdFunctions` detailed sections.
This is useful to get a quick summary of what is in a Go binary.
The default is to always print the function sections.

Reference: https://github.com/mandiant/GoReSym/issues/49
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>