### PR TITLE
Include start/end virtual addresses for extracted Go strings

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ type ExtractMetadata struct {
 	Files         []string
 	UserFunctions []FuncMetadata
 	StdFunctions  []FuncMetadata
-	Strings       []string
+	Strings       []objfile.GoString
 }
 
 func main_impl_tmpfile(fileBytes []byte, printStdPkgs bool, printFilePaths bool, printTypes bool, noPrintFunctions bool, manualTypeAddress int, versionOverride string, printStrings bool) (metadata ExtractMetadata, err error) {


### PR DESCRIPTION
This change updates ExtractMetadata.Strings to return objfile.GoString
instead of []string, allowing extracted Go strings to include their
start and end virtual addresses.

This builds on the existing -strings implementation and enables
downstream tooling (e.g. IDA / Binary Ninja plugins) to place string
literals at precise locations.

No behavioral changes when -strings is not used.