### PR TITLE
Add string start addresses to -strings output

### DIFF
--- a/GoReSym.proto
+++ b/GoReSym.proto
@@ -34,6 +34,11 @@ message ModuleData {
     uint64 textVa = 7 [json_name="TextVA"];
 }
 
+message StringEntry {
+    string str = 1 [json_name="Str"];
+    uint64 start = 2 [json_name="Start"];
+}
+
 message Type {
     uint64 va = 1 [json_name="VA"];
     string str = 2 [json_name="Str"];
@@ -74,5 +79,5 @@ message ExtractMetadata {
     repeated string files = 10 [json_name="Files"];
     repeated FuncMetadata userFunctions = 11 [json_name="UserFunctions"];
     repeated FuncMetadata stdFunctions = 12 [json_name="StdFunctions"];
-    repeated string strings = 13 [json_name="Strings"];
+    repeated StringEntry strings = 13 [json_name="Strings"];
 }

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ type ExtractMetadata struct {
 	Files         []string
 	UserFunctions []FuncMetadata
 	StdFunctions  []FuncMetadata
-	Strings       []string
+	Strings       []objfile.StringEntry
 }
 
 func main_impl_tmpfile(fileBytes []byte, printStdPkgs bool, printFilePaths bool, printTypes bool, noPrintFunctions bool, manualTypeAddress int, versionOverride string, printStrings bool) (metadata ExtractMetadata, err error) {
@@ -388,8 +388,8 @@ func printForHuman(metadata ExtractMetadata) {
 
 	fmt.Println("\n-Strings-")
 	if len(metadata.Strings) > 0 {
-		for _, str := range metadata.Strings {
-			fmt.Println(str)
+		for _, s := range metadata.Strings {
+			fmt.Printf("0x%x %s\n", s.Start, s.Str)
 		}
 	} else {
 		fmt.Println("<NO STRINGS EXTRACTED>")

--- a/main_test.go
+++ b/main_test.go
@@ -396,11 +396,14 @@ func TestStringExtraction(t *testing.T) {
 				t.Errorf("Expected at least %d strings from %s, got %d", tc.minStrings, tc.description, len(data.Strings))
 			}
 
-			// Check that all extracted strings are printable
+			// Check that all extracted strings are printable and have a non-zero start address
 			nonPrintableCount := 0
-			for _, str := range data.Strings {
-				if !isPrintable(str) {
+			for _, entry := range data.Strings {
+				if !isPrintable(entry.Str) {
 					nonPrintableCount++
+				}
+				if entry.Start == 0 {
+					t.Errorf("String %q has zero start address in %s", entry.Str, tc.description)
 				}
 			}
 
@@ -415,8 +418,8 @@ func TestStringExtraction(t *testing.T) {
 			expectedSubstrings := []string{"main", "go", "runtime"}
 			foundCount := 0
 			for _, expected := range expectedSubstrings {
-				for _, str := range data.Strings {
-					if strings.Contains(str, expected) {
+				for _, entry := range data.Strings {
+					if strings.Contains(entry.Str, expected) {
 						foundCount++
 						break
 					}

--- a/objfile/strings.go
+++ b/objfile/strings.go
@@ -46,10 +46,16 @@ type StringCandidate struct {
 	Length  uint64 // Length of the string in bytes
 }
 
+// StringEntry is a validated Go string with its virtual address in the binary.
+type StringEntry struct {
+	Str   string `json:"Str"`
+	Start uint64 `json:"Start"`
+}
+
 // ExtractStrings finds embedded Go strings in the binary by analyzing the
-// string internment table. Returns deduplicated, validated strings.
-func (f *File) ExtractStrings() ([]string, error) {
-	var allStrings []string
+// string internment table. Returns deduplicated, validated strings with their start VAs.
+func (f *File) ExtractStrings() ([]StringEntry, error) {
+	var allStrings []StringEntry
 
 	for _, entry := range f.entries {
 		strings, err := entry.extractStrings()
@@ -67,7 +73,7 @@ func (f *File) ExtractStrings() ([]string, error) {
 // This is the main orchestration function, following the FLOSS algorithm:
 //
 //	FLOSS: get_string_blob_strings() in extract.py:266
-func (e *Entry) extractStrings() ([]string, error) {
+func (e *Entry) extractStrings() ([]StringEntry, error) {
 	is64bit := e.is64Bit()
 	isLittleEndian := e.isLittleEndian()
 
@@ -128,7 +134,7 @@ func (e *Entry) extractStrings() ([]string, error) {
 	}
 
 	if len(allCandidates) == 0 {
-		return []string{}, nil
+		return []StringEntry{}, nil
 	}
 
 	// ---------------------------------------------------------------
@@ -154,7 +160,7 @@ func (e *Entry) extractStrings() ([]string, error) {
 	// entries long, far longer than any random run.
 	runStart, runEnd := findLongestMonotonicRun(allCandidates)
 	if runStart == -1 || runEnd == -1 {
-		return []string{}, nil
+		return []StringEntry{}, nil
 	}
 
 	// ---------------------------------------------------------------
@@ -167,7 +173,7 @@ func (e *Entry) extractStrings() ([]string, error) {
 	// null sequences before and after to delimit the blob.
 	blobStart, blobEnd, blobData := findStringBlobRange(allCandidates, runStart, runEnd, dataSections)
 	if blobData == nil {
-		return []string{}, nil
+		return []StringEntry{}, nil
 	}
 
 	// ---------------------------------------------------------------
@@ -184,7 +190,7 @@ func (e *Entry) extractStrings() ([]string, error) {
 	// The blob boundary still serves its purpose: only candidates whose
 	// pointer falls within the blob are considered (filtering noise).
 	seen := make(map[string]bool)
-	var result []string
+	var result []StringEntry
 
 	for _, c := range allCandidates {
 		// Only consider candidates pointing into the blob
@@ -222,7 +228,7 @@ func (e *Entry) extractStrings() ([]string, error) {
 		}
 		seen[s] = true
 
-		result = append(result, s)
+		result = append(result, StringEntry{Str: s, Start: c.Pointer})
 	}
 
 	return result, nil

--- a/objfile/strings_floss_test.go
+++ b/objfile/strings_floss_test.go
@@ -52,7 +52,7 @@ func TestExtractStrings_CompareWithFLOSS(t *testing.T) {
 	// Convert to set
 	goresymSet := make(map[string]bool)
 	for _, s := range goresymStrings {
-		goresymSet[s] = true
+		goresymSet[s.Str] = true
 	}
 
 	// Calculate overlap

--- a/objfile/strings_test.go
+++ b/objfile/strings_test.go
@@ -135,8 +135,8 @@ func TestExtractStrings_MinLength(t *testing.T) {
 
 	// All strings must be >= 4 characters (MIN_STRING_LENGTH)
 	for _, s := range strings {
-		if len(s) < 4 {
-			t.Errorf("Found string shorter than 4 chars: %q (len=%d)", s, len(s))
+		if len(s.Str) < 4 {
+			t.Errorf("Found string shorter than 4 chars: %q (len=%d)", s.Str, len(s.Str))
 		}
 	}
 }
@@ -329,11 +329,11 @@ func TestFindStringCandidates(t *testing.T) {
 }
 
 // Helper function to check if expected strings are present
-func assertStringsPresent(t *testing.T, strings []string, expected []string) {
+func assertStringsPresent(t *testing.T, entries []StringEntry, expected []string) {
 	t.Helper()
 	stringSet := make(map[string]bool)
-	for _, s := range strings {
-		stringSet[s] = true
+	for _, e := range entries {
+		stringSet[e.Str] = true
 	}
 
 	for _, exp := range expected {


### PR DESCRIPTION
Closes #99

## Summary

- Added `StringEntry` struct (`Str string`, `Start uint64`) to `objfile/strings.go` — replaces bare `string` in the output
- `ExtractStrings()` now returns `[]StringEntry` instead of `[]string`; the start VA comes directly from `c.Pointer` which was already computed during blob walking
- Updated `ExtractMetadata.Strings` in `main.go` from `[]string` to `[]objfile.StringEntry`
- `-human` output now prints `0x<addr> <string>` per entry
- Added `StringEntry` message to `GoReSym.proto`; changed `repeated string strings` → `repeated StringEntry strings`
- Tests updated to use `.Str` field and assert `Start != 0` for every extracted string

## Example output change

**Before:**
```json
"Strings": ["main", "runtime.goexit"]
```

**After:**
```json
"Strings": [{"Str": "main", "Start": 4890624}, {"Str": "runtime.goexit", "Start": 4891136}]
```

## Notes

- Only `Start` is included per Steve's guidance — consumers can derive `End` from `Start + len(Str)`
- Deduplication by string value is preserved; all candidates referencing the same string point to the same blob offset so the captured address is always correct
- No new dependencies introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)